### PR TITLE
Cleanup

### DIFF
--- a/agent/src/command/health.rs
+++ b/agent/src/command/health.rs
@@ -4,6 +4,7 @@ use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
 use crate::common::config::{DEFAULT_NODE_ADDR, DEFAULT_PROTOCOL, DEFAULT_RPC_ENDPOINT};
+use crate::common::error::Error;
 use crate::common::handlers::{CommandLineHandler, RPCNodeHandler};
 use crate::common::rpc::{JSONRPCParam, JSONRPCResponse};
 
@@ -36,16 +37,14 @@ pub struct HealthCheckCmd {}
 #[async_trait]
 impl CommandLineHandler for HealthCheckCmd {
     type Request = HealthCheck;
-    type Error = ();
 
-    async fn handle(request: &Self::Request) -> Result<(), Self::Error> {
+    async fn handle(request: &Self::Request) -> Result<String, Error> {
         let node = request.node_endpoint.as_ref().unwrap_or(&DEFAULT_URL);
         if is_health(node).await {
-            println!("node: {:} is healthy", node);
+            Ok(format!("node: {:} is healthy", node))
         } else {
-            println!("node: {:} is not healthy", node);
+            Err(Error::Custom(format!("node: {:} is down", node)))
         }
-        Ok(())
     }
 }
 
@@ -66,12 +65,11 @@ async fn is_health(node: &str) -> bool {
     let client = reqwest::Client::new();
     match client
         .post(node)
-        .json(&JSONRPCParam {
-            id: 0,
-            jsonrpc: "2.0".to_string(),
-            method: "health_check".to_string(),
-            params: serde_json::Value::Null,
-        })
+        .json(&JSONRPCParam::new(
+            0,
+            "health_check".to_string(),
+            serde_json::Value::Null,
+        ))
         .send()
         .await
     {

--- a/agent/src/command/health.rs
+++ b/agent/src/command/health.rs
@@ -9,10 +9,8 @@ use crate::common::handlers::{CommandLineHandler, RPCNodeHandler};
 use crate::common::rpc::{JSONRPCParam, JSONRPCResponse};
 
 lazy_static! {
-    static ref DEFAULT_URL: String = format!(
-        "{}://{}/{}",
-        DEFAULT_PROTOCOL, DEFAULT_NODE_ADDR, DEFAULT_RPC_ENDPOINT
-    );
+    static ref DEFAULT_URL: String =
+        format!("{DEFAULT_PROTOCOL}://{DEFAULT_NODE_ADDR}/{DEFAULT_RPC_ENDPOINT}");
 }
 
 #[derive(Debug, Args)]
@@ -41,9 +39,9 @@ impl CommandLineHandler for HealthCheckCmd {
     async fn handle(request: &Self::Request) -> Result<String, Error> {
         let node = request.node_endpoint.as_ref().unwrap_or(&DEFAULT_URL);
         if is_health(node).await {
-            Ok(format!("node: {:} is healthy", node))
+            Ok(format!("node: {node:} is healthy"))
         } else {
-            Err(Error::Custom(format!("node: {:} is down", node)))
+            Err(Error::Custom(format!("node: {node:} is down")))
         }
     }
 }
@@ -60,7 +58,7 @@ impl RPCNodeHandler for HealthCheckCmd {
 }
 
 async fn is_health(node: &str) -> bool {
-    log::debug!("health check endpoint: {:}", node);
+    log::debug!("health check endpoint: {node:}");
 
     let client = reqwest::Client::new();
     match client

--- a/agent/src/command/mod.rs
+++ b/agent/src/command/mod.rs
@@ -1,1 +1,2 @@
 pub mod health;
+pub mod node;

--- a/agent/src/command/node.rs
+++ b/agent/src/command/node.rs
@@ -1,0 +1,47 @@
+use async_trait::async_trait;
+use clap::Args;
+use serde::{de::DeserializeOwned, Deserialize};
+
+use crate::common::config::ClientNodeConfig;
+use crate::common::error::Error;
+use crate::common::handlers::CommandLineHandler;
+
+/// The config struct used parsed from cli
+#[derive(Deserialize, Debug, Default, Args)]
+#[command(about = "Launches the IPC node")]
+pub struct NodeLaunch {
+    #[arg(
+        long = "config",
+        value_name = "CONFIG_FILE_PATH",
+        help = "The config file path for the IPC client node",
+        env = "IPC_CLIENT_NODE_CONFIG"
+    )]
+    config_path: Option<String>,
+}
+
+impl NodeLaunch {
+    pub fn client_node_config(&self) -> ClientNodeConfig {
+        self.config_path
+            .as_ref()
+            .map(|s| parse_yaml(s))
+            .unwrap_or_default()
+    }
+}
+
+pub struct NodeCmd {}
+
+#[async_trait]
+impl CommandLineHandler for NodeCmd {
+    type Request = NodeLaunch;
+
+    async fn handle(request: &Self::Request) -> Result<String, Error> {
+        let node_config = request.client_node_config();
+        crate::node::IPCClientNode::new(node_config).run().await;
+        Ok(String::from("node up"))
+    }
+}
+
+fn parse_yaml<T: DeserializeOwned>(path: &str) -> T {
+    let raw = std::fs::read_to_string(path).expect("cannot read config yaml");
+    serde_yaml::from_str(&raw).expect("cannot parse yaml")
+}

--- a/agent/src/common/error.rs
+++ b/agent/src/common/error.rs
@@ -1,0 +1,8 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    /// Custom error with string as the detailed message
+    #[error("Custom error: {0}")]
+    Custom(String),
+}

--- a/agent/src/common/handlers.rs
+++ b/agent/src/common/handlers.rs
@@ -1,3 +1,4 @@
+use crate::common::error::Error;
 use async_trait::async_trait;
 use clap::Args;
 
@@ -10,11 +11,9 @@ pub trait CommandLineHandler {
     /// Currently we are directly integrating with `clap` crate. In the future we can use our own
     /// implementation to abstract away external crates. But this should be good for now.
     type Request: std::fmt::Debug + Args;
-    /// The error thrown
-    type Error: std::fmt::Debug;
 
     /// Handles the request and produces a response
-    async fn handle(request: &Self::Request) -> Result<(), Self::Error>;
+    async fn handle(request: &Self::Request) -> Result<String, Error>;
 }
 
 /// The common trait for json-rpc handler

--- a/agent/src/common/mod.rs
+++ b/agent/src/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod config;
+pub mod error;
 pub mod handlers;
 pub mod macros;
 pub mod rpc;

--- a/agent/src/common/rpc.rs
+++ b/agent/src/common/rpc.rs
@@ -1,4 +1,9 @@
+use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+
+lazy_static! {
+    static ref DEFAULT_JSON_RPC: String = String::from("2.0");
+}
 
 /// Follows: https://ethereum.org/en/developers/docs/apis/json-rpc/#curl-examples
 #[derive(Serialize, Deserialize)]
@@ -7,6 +12,17 @@ pub struct JSONRPCParam {
     pub jsonrpc: String,
     pub method: String,
     pub params: serde_json::Value,
+}
+
+impl JSONRPCParam {
+    pub fn new(id: u16, method: String, params: serde_json::Value) -> Self {
+        JSONRPCParam {
+            id,
+            jsonrpc: DEFAULT_JSON_RPC.clone(),
+            method,
+            params,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -1,2 +1,0 @@
-pub mod command;
-pub mod common;

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -15,6 +15,9 @@ register_server_routes!(
 
         (h1, h2)
     },
+    // health_check method is associated with h1
+    // health_check2 method is associated with h2
+    // TODO: find a clearer way to association and not by convention
     commands: health_check, health_check2
 );
 

--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -1,11 +1,14 @@
-use agent::command::health::HealthCheckCmd;
-use agent::{register_cli_command, register_server_routes};
+mod command;
+mod common;
+
+use crate::command::health::HealthCheckCmd;
+use crate::command::node::NodeCmd;
 
 // define the routes here
 register_server_routes!(
     // initialize your server RPC handlers here, returns the handlers as a tuple
     init: {
-        use agent::command::health::HealthCheckCmd;
+        use crate::command::health::HealthCheckCmd;
 
         let h1 = HealthCheckCmd {};
         let h2 = HealthCheckCmd {};
@@ -19,11 +22,13 @@ register_server_routes!(
 register_cli_command!(
     // { COMMAND NAME, HANDLER }
     {HealthCheck, HealthCheckCmd},
-    {Node, node::NodeCmd}
+    {Node, NodeCmd}
 );
 
 #[tokio::main]
 async fn main() {
-    env_logger::init();
+    env_logger::init_from_env(
+        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
+    );
     cli().await;
 }


### PR DESCRIPTION
## Changes

<!--

Please provide a brief but specific list of changes made, describe the changes
in functionality rather than the changes in code.

-->

Clean up as follows:
- [x] Info logger by default for node.
- [x] Make the initialization of the node not in the macro but in the commands to be able to change the processes that we run.
- [ ] Enum register_server_routes! ideally should be an enum or vector.
- [x] JSONRPCParam should take the jsonrpc version from a config or a const (like we do with other configs).
- [x] Make CommandLineHandler return loggers for success and failures instead of println. Maybe instead of returning a Result<(), Error> we could automatically process the Result and output the loggers accordingly

`Enum register_server_routes! ideally should be an enum or vector.` is not done yet because there are some difficulties around integrating with futures and capturing variables in `wrap`. Added a todo in the code and will come up with ways to simplify this further down the road.
 
## Tests

<!--

Details on how to run tests relevant to the changes within this pull request.

-->

```
cargo build
./target/debug/agent node
./target/debug/agent health-check
```
