### PR TITLE
Add cli command handler interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ base64 = "0.21.0"
 strum = { version = "0.24", features = ["derive"] }
 toml = "0.7.2"
 url = { version = "2.3.1", features = ["serde"] }
+clap = {version = "4.1.4", features = ["env", "derive"] }
 
 fvm_shared = {workspace = true}
 fil_actors_runtime = {workspace = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ strum = { version = "0.24", features = ["derive"] }
 toml = "0.7.2"
 url = { version = "2.3.1", features = ["serde"] }
 clap = {version = "4.1.4", features = ["env", "derive"] }
+thiserror = "1.0.38"
 
 fvm_shared = {workspace = true}
 fil_actors_runtime = {workspace = true}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -15,6 +15,6 @@ pub trait CommandLineHandler {
     /// implementation to abstract away external crates. But this should be good for now.
     type Arguments: std::fmt::Debug + Args;
 
-    /// Handles the request and produces a response string.
+    /// Handles the request with the provided arguments. Dev should handle the content to print and how
     async fn handle(arguments: &Self::Arguments) -> anyhow::Result<()>;
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,13 +10,13 @@ use clap::Args;
 /// constructed from scratch. Initialize the states in the `handle` method.
 #[async_trait]
 pub trait CommandLineHandler {
-    /// The request to process.
+    /// The command line argument to process.
     ///
     /// NOTE that this parameter is used to generate the command line arguments.
     /// Currently we are directly integrating with `clap` crate. In the future we can use our own
     /// implementation to abstract away external crates. But this should be good for now.
-    type Request: std::fmt::Debug + Args;
+    type Argument: std::fmt::Debug + Args;
 
     /// Handles the request and produces a response string.
-    async fn handle(request: &Self::Request) -> Result<String, Error>;
+    async fn handle(request: &Self::Argument) -> Result<String, Error>;
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,8 +7,7 @@ use clap::Args;
 /// how to register.
 ///
 /// Note that this trait does not support a stateful implementation as we assume CLI commands are all
-/// constructed from scratch. Initialize the states in the `handle` method or pass in from the
-/// implementation constructor.
+/// constructed from scratch. Initialize the states in the `handle` method.
 #[async_trait]
 pub trait CommandLineHandler {
     /// The request to process.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,23 @@
+use crate::error::Error;
+use async_trait::async_trait;
+use clap::Args;
+
+/// The trait that represents the abstraction of a command line handler. To implement a new command
+/// line operation, implement this trait and register it, see `register::register_cli_command` for
+/// how to register.
+///
+/// Note that this trait does not support a stateful implementation as we assume CLI commands are all
+/// constructed from scratch. Initialize the states in the `handle` method or pass in from the
+/// implementation constructor.
+#[async_trait]
+pub trait CommandLineHandler {
+    /// The request to process.
+    ///
+    /// NOTE that this parameter is used to generate the command line arguments.
+    /// Currently we are directly integrating with `clap` crate. In the future we can use our own
+    /// implementation to abstract away external crates. But this should be good for now.
+    type Request: std::fmt::Debug + Args;
+
+    /// Handles the request and produces a response string.
+    async fn handle(request: &Self::Request) -> Result<String, Error>;
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,4 @@ use thiserror::Error;
 /// The error enum that can be used across the crate.
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("Command line failed with error: {0}")]
-    CommandLine(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,8 @@
+use thiserror::Error;
+
+/// The error enum that can be used across the crate.
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("Command line failed with error: {0}")]
+    CommandLine(String),
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 mod jsonrpc;
 mod config;
 mod lotus;
+mod cli;
+mod error;
 
 fn main() {}


### PR DESCRIPTION
This PR is the start of the series to introduce Command Line handling. The overall idea is, when adding a new command, one just needs to implement the core execution logic. The parsing of command line args, dispatching and response display are already taken care of. One just needs to register the handler to a registry. 

This PR introduces the trait that represents the abstraction of a command line handler.  To implement a new command line operation, implement this trait.

Example code can be found in #12.
