### PR TITLE
Fixes error checking in JsonRpcClient requests and tests

### DIFF
--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -90,7 +90,7 @@ impl JsonRpcClient for JsonRpcClientImpl {
 
         let value = serde_json::from_str::<JsonRpcResponse<T>>(response_body.as_ref())?;
 
-        if value.id == DEFAULT_JSON_RPC_ID || value.jsonrpc == DEFAULT_JSON_RPC_VERSION {
+        if value.id != DEFAULT_JSON_RPC_ID || value.jsonrpc != DEFAULT_JSON_RPC_VERSION {
             return Err(anyhow!("json_rpc id or version not matching."));
         }
 
@@ -108,7 +108,6 @@ impl JsonRpcClient for JsonRpcClientImpl {
         }
 
         let (mut ws_stream, _) = connect_async(request).await?;
-        //let (mut ws_stream, _) = connect_async(self.url.as_str()).await?;
         let request_body = build_jsonrpc_request(method, NO_PARAMS)?;
         ws_stream
             .send(Message::text(request_body.to_string()))

--- a/src/jsonrpc/tests.rs
+++ b/src/jsonrpc/tests.rs
@@ -8,7 +8,6 @@ const HTTP_ENDPOINT: &str = "https://api.node.glif.io/rpc/v0";
 const WS_ENDPOINT: &str = "wss://wss.node.glif.io/apigw/lotus/rpc/v0";
 
 #[tokio::test]
-#[ignore]
 async fn test_request() {
     let url = Url::parse(HTTP_ENDPOINT).unwrap();
     let client = JsonRpcClientImpl::new(url, None);
@@ -21,7 +20,6 @@ async fn test_request() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_request_error() {
     let url = Url::parse(HTTP_ENDPOINT).unwrap();
     let client = JsonRpcClientImpl::new(url, None);
@@ -33,7 +31,6 @@ async fn test_request_error() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_request_with_params() {
     let url = Url::parse(HTTP_ENDPOINT).unwrap();
     let client = JsonRpcClientImpl::new(url, None);
@@ -46,7 +43,6 @@ async fn test_request_with_params() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_request_with_params_error() {
     let url = Url::parse(HTTP_ENDPOINT).unwrap();
     let client = JsonRpcClientImpl::new(url, None);
@@ -54,7 +50,7 @@ async fn test_request_with_params_error() {
     let response = client
         .request::<serde_json::Value>("Filecoin.ChainGetBlock", NO_PARAMS)
         .await;
-    assert!(response.is_ok());
+    assert!(response.is_err());
 }
 
 #[tokio::test]
@@ -63,7 +59,7 @@ async fn test_subscribe() {
     let url = Url::parse(WS_ENDPOINT).unwrap();
     let client = JsonRpcClientImpl::new(url, None);
     let mut chan = client.subscribe("Filecoin.ChainNotify").await.unwrap();
-    for _ in 1..=3 {
+    for _ in 1..=1 {
         chan.next().await.unwrap();
     }
 }

--- a/src/jsonrpc/tests.rs
+++ b/src/jsonrpc/tests.rs
@@ -59,7 +59,7 @@ async fn test_subscribe() {
     let url = Url::parse(WS_ENDPOINT).unwrap();
     let client = JsonRpcClientImpl::new(url, None);
     let mut chan = client.subscribe("Filecoin.ChainNotify").await.unwrap();
-    for _ in 1..=1 {
+    for _ in 1..=3 {
         chan.next().await.unwrap();
     }
 }


### PR DESCRIPTION
This PR fixes a bug in checking the ID and version fields in the `request` method of `JsonRpcClientImpl`. It also fixes some related tests and removes the `ignore` directive on the less flaky tests.