### PR TITLE
IPC-17: Create ipld/resolver crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,16 @@
+[workspace]
+members = [".", "ipld/resolver"]
+
+[workspace.package]
+authors = ["Protocol Labs"]
+edition = "2021"
+license = "MIT OR Apache-2.0"
+
 [package]
 name = "ipc-client"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -27,11 +36,11 @@ toml = "0.7.2"
 url = { version = "2.3.1", features = ["serde"] }
 warp = "0.3.3"
 bytes = "1.4.0"
-clap = {version = "4.1.4", features = ["env", "derive"] }
+clap = { version = "4.1.4", features = ["env", "derive"] }
 thiserror = "1.0.38"
 
-fvm_shared = {workspace = true}
-fil_actors_runtime = {workspace = true}
+fvm_shared = { workspace = true }
+fil_actors_runtime = { workspace = true }
 ipc-sdk = { workspace = true }
 ipc-subnet-actor = { workspace = true }
 ipc-gateway = { workspace = true }
@@ -42,4 +51,3 @@ fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", 
 ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-actors.git" }
 ipc-subnet-actor = { git = "https://github.com/consensus-shipyard/ipc-actors.git", features = [] }
 ipc-gateway = { git = "https://github.com/consensus-shipyard/ipc-actors.git", features = [] }
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,13 @@ members = [".", "ipld/resolver"]
 [workspace.package]
 authors = ["Protocol Labs"]
 edition = "2021"
-license = "MIT OR Apache-2.0"
+license-file = "LICENSE"
 
 [package]
 name = "ipc-client"
 version = "0.1.0"
 edition.workspace = true
-license.workspace = true
+license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ipc_ipld_resolver"
+description = "P2P library to resolve IPLD content across IPC subnets."
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -4,7 +4,7 @@ description = "P2P library to resolve IPLD content across IPC subnets."
 version = "0.1.0"
 authors.workspace = true
 edition.workspace = true
-license.workspace = true
+license-file.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ipld/resolver/src/lib.rs
+++ b/ipld/resolver/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: usize, right: usize) -> usize {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2022-10-03"
+components = ["clippy", "llvm-tools-preview", "rustfmt"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Related to #17 

The PR creates an `ipld/resolver` crate and puts it in the workspace. 

Also added a `rust-toolchain.toml` file with the same content as `ref-fvm` - without it I wasn't able to build the actor dependencies due to wasm stuff. Nightly and the wasm-target seems to fix the issue, and at least we'd all be on the same config.