### PR TITLE
Add a method to LotusClient for retrieving the chain head

### DIFF
--- a/src/lotus/client.rs
+++ b/src/lotus/client.rs
@@ -120,10 +120,9 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
 
     async fn state_network_version(&self, tip_sets: Vec<Cid>) -> Result<NetworkVersion> {
         // refer to: https://lotus.filecoin.io/reference/lotus/state/#statenetworkversion
-        let params = json!([tip_sets
-            .into_iter()
-            .map(|cid| CIDMap::from(cid))
-            .collect::<Vec<_>>()]);
+        let params = json!([
+            tip_sets.into_iter().map(|cid| CIDMap::from(cid)).collect::<Vec<_>>()
+        ]);
 
         let r = self
             .client
@@ -134,10 +133,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
         Ok(r)
     }
 
-    async fn state_actor_code_cids(
-        &self,
-        network_version: NetworkVersion,
-    ) -> Result<HashMap<String, Cid>> {
+    async fn state_actor_code_cids(&self, network_version: NetworkVersion) -> Result<HashMap<String, Cid>> {
         // refer to: https://github.com/filecoin-project/lotus/blob/master/documentation/en/api-v1-unstable-methods.md#stateactormanifestcid
         let params = json!([network_version]);
 

--- a/src/lotus/client.rs
+++ b/src/lotus/client.rs
@@ -1,11 +1,8 @@
 use std::collections::HashMap;
-use crate::lotus::message::{
-    CIDMap, MpoolPushMessage, MpoolPushMessageResponse, MpoolPushMessageResponseInner,
-    ReadStateResponse, StateWaitMsgResponse, WalletKeyType, WalletListResponse,
-};
-use crate::jsonrpc::JsonRpcClient;
-use crate::lotus::{LotusClient, NetworkVersion};
-use anyhow::{anyhow, Result};
+use std::fmt::Debug;
+use std::str::FromStr;
+
+use anyhow::Result;
 use async_trait::async_trait;
 use cid::Cid;
 use fvm_shared::address::Address;
@@ -13,8 +10,14 @@ use fvm_shared::econ::TokenAmount;
 use num_traits::cast::ToPrimitive;
 use serde::de::DeserializeOwned;
 use serde_json::json;
-use std::fmt::Debug;
-use std::str::FromStr;
+
+use crate::jsonrpc::{JsonRpcClient, NO_PARAMS};
+use crate::lotus::message::{
+    CIDMap, ChainHeadResponse, MpoolPushMessage, MpoolPushMessageResponse,
+    MpoolPushMessageResponseInner, ReadStateResponse, StateWaitMsgResponse, WalletKeyType,
+    WalletListResponse,
+};
+use crate::lotus::{LotusClient, NetworkVersion};
 
 // RPC methods
 mod methods {
@@ -27,6 +30,7 @@ mod methods {
     pub const WALLET_LIST: &str = "Filecoin.WalletList";
     pub const WALLET_DEFAULT_ADDRESS: &str = "Filecoin.WalletDefaultAddress";
     pub const STATE_READ_STATE: &str = "Filecoin.StateReadState";
+    pub const CHAIN_HEAD: &str = "Filecoin.ChainHead";
 }
 
 /// The struct implementation for Lotus Client API. It allows for multiple different trait
@@ -116,9 +120,10 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
 
     async fn state_network_version(&self, tip_sets: Vec<Cid>) -> Result<NetworkVersion> {
         // refer to: https://lotus.filecoin.io/reference/lotus/state/#statenetworkversion
-        let params = json!([
-            tip_sets.into_iter().map(|cid| CIDMap::from(cid)).collect::<Vec<_>>()
-        ]);
+        let params = json!([tip_sets
+            .into_iter()
+            .map(|cid| CIDMap::from(cid))
+            .collect::<Vec<_>>()]);
 
         let r = self
             .client
@@ -129,7 +134,10 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
         Ok(r)
     }
 
-    async fn state_actor_code_cids(&self, network_version: NetworkVersion) -> Result<HashMap<String, Cid>> {
+    async fn state_actor_code_cids(
+        &self,
+        network_version: NetworkVersion,
+    ) -> Result<HashMap<String, Cid>> {
         // refer to: https://github.com/filecoin-project/lotus/blob/master/documentation/en/api-v1-unstable-methods.md#stateactormanifestcid
         let params = json!([network_version]);
 
@@ -194,6 +202,15 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             )
             .await?;
         log::debug!("received read_state response: {r:?}");
+        Ok(r)
+    }
+
+    async fn chain_head(&self) -> Result<ChainHeadResponse> {
+        let r = self
+            .client
+            .request::<ChainHeadResponse>(methods::CHAIN_HEAD, NO_PARAMS)
+            .await?;
+        log::debug!("received chain_head response: {r:?}");
         Ok(r)
     }
 }

--- a/src/lotus/message.rs
+++ b/src/lotus/message.rs
@@ -7,6 +7,7 @@ use fvm_shared::MethodNum;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use anyhow::anyhow;
+use serde_json::Value;
 use strum::{AsRefStr, Display, EnumString};
 
 /// Exec actor parameters
@@ -160,6 +161,18 @@ impl MpoolPushMessage {
             max_fee: None,
         }
     }
+}
+
+/// A simplified struct representing a `ChainHead` response that does not decode the `blocks` field.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct ChainHeadResponse {
+    #[allow(dead_code)]
+    pub cids: Vec<CIDMap>,
+    #[allow(dead_code)]
+    pub blocks: Vec<Value>,
+    #[allow(dead_code)]
+    pub height: u64,
 }
 
 impl TryFrom<CIDMap> for Cid {

--- a/src/lotus/mod.rs
+++ b/src/lotus/mod.rs
@@ -17,6 +17,7 @@ pub use crate::lotus::message::{MpoolPushMessage, MpoolPushMessageResponseInner}
 pub use crate::lotus::message::{
     ReadStateResponse, StateWaitMsgResponse, WalletKeyType, WalletListResponse,
 };
+use crate::lotus::message::ChainHeadResponse;
 
 /// The network version of lotus network.
 /// see https://github.com/filecoin-project/go-state-types/blob/f6fd668a32b4b4a0bc39fd69d8a5f8fb11f49461/network/version.go#L7
@@ -58,4 +59,8 @@ pub trait LotusClient {
         address: Address,
         tipset: Cid,
     ) -> Result<ReadStateResponse<State>>;
+
+    /// Returns the current head of the chain.
+    /// See: https://lotus.filecoin.io/reference/lotus/chain/#chainhead
+    async fn chain_head(&self) -> Result<ChainHeadResponse>;
 }

--- a/src/lotus/mod.rs
+++ b/src/lotus/mod.rs
@@ -15,9 +15,8 @@ use std::fmt::Debug;
 pub use crate::lotus::client::LotusJsonRPCClient;
 pub use crate::lotus::message::{MpoolPushMessage, MpoolPushMessageResponseInner};
 pub use crate::lotus::message::{
-    ReadStateResponse, StateWaitMsgResponse, WalletKeyType, WalletListResponse,
+    ChainHeadResponse, ReadStateResponse, StateWaitMsgResponse, WalletKeyType, WalletListResponse,
 };
-use crate::lotus::message::ChainHeadResponse;
 
 /// The network version of lotus network.
 /// see https://github.com/filecoin-project/go-state-types/blob/f6fd668a32b4b4a0bc39fd69d8a5f8fb11f49461/network/version.go#L7

--- a/src/lotus/tests.rs
+++ b/src/lotus/tests.rs
@@ -37,3 +37,12 @@ async fn state_actor_manifest_cid() {
     let cids = client.state_actor_code_cids(version).await.unwrap();
     assert!(!cids.is_empty());
 }
+
+#[tokio::test]
+async fn chain_head() {
+    let client = get_lotus_client();
+    let head = client.chain_head().await.unwrap();
+    assert!(!head.cids.is_empty());
+    assert!(!head.blocks.is_empty());
+    assert_eq!(head.cids.len(), head.blocks.len());
+}


### PR DESCRIPTION
The first of a series of changes to add new JSON-RPC method calls to the `LotusClient` necessary for checkpointing implementation. This one adds the `ChainHead` call. The deserialization is done into a simplified data structure that does not decode the entire response. In particular, we leave out the `blocks` field due to its complexity which is unnecessary for our purposes.