### PR TITLE
IPC-35: Membership

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.16", features = ["full"] }
+quickcheck = "1"
+quickcheck_macros = "1"
+
 
 fvm_ipld_encoding = "0.3"
 fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures-util = { version = "0.3", default-features = false, features = ["sink", 
 indoc = "2.0.0"
 log = { workspace = true }
 reqwest = { version = "0.11.13", features = ["json"] }
-serde = { version = "1.0.152", features = ["derive"] }
+serde = { workspace = true }
 serde_json = "1.0.91"
 cid = { version = "0.8.3", default-features = false, features = ["serde-codec"] }
 tokio = { workspace = true }
@@ -49,11 +49,12 @@ fvm_ipld_encoding = { workspace = true }
 
 [workspace.dependencies]
 anyhow = "1.0"
+log = "0.4"
+serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.16", features = ["full"] }
-log = "0.4"
 
-fvm_ipld_encoding = "0.3.3"
+fvm_ipld_encoding = "0.3"
 fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
 ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-actors.git" }

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -27,11 +27,24 @@ libp2p = { version = "0.50", default-features = false, features = [
   "tokio",
   "macros",
   "serde",
+  "secp256k1",
 ] }
 libp2p-bitswap = "0.25"
 libipld = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
+quickcheck = { workspace = true, optional = true }
 
 ipc-sdk = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
+fvm_shared = { workspace = true, optional = true }
+
+[dev-dependencies]
+quickcheck = { workspace = true }
+quickcheck_macros = { workspace = true }
+fvm_shared = { workspace = true, features = ["arb"] }
+
+
+[features]
+default = ["arb"]
+arb = ["quickcheck", "fvm_shared/arb"]

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -12,7 +12,26 @@ license-file.workspace = true
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-libp2p = { version = "0.50", default-features = false, features = ["gossipsub", "kad", "identify", "ping", "noise", "yamux", "tcp", "dns", "mplex", "request-response", "metrics", "tokio", "macros"] }
+libp2p = { version = "0.50", default-features = false, features = [
+  "gossipsub",
+  "kad",
+  "identify",
+  "ping",
+  "noise",
+  "yamux",
+  "tcp",
+  "dns",
+  "mplex",
+  "request-response",
+  "metrics",
+  "tokio",
+  "macros",
+  "serde",
+] }
 libp2p-bitswap = "0.25"
 libipld = { workspace = true }
 log = { workspace = true }
+serde = { workspace = true }
+
+ipc-sdk = { workspace = true }
+fvm_ipld_encoding = { workspace = true }

--- a/ipld/resolver/src/arb.rs
+++ b/ipld/resolver/src/arb.rs
@@ -1,0 +1,18 @@
+use fvm_shared::address::Address;
+use quickcheck::Arbitrary;
+
+/// Unfortunately an arbitrary `DelegatedAddress` can be inconsistent
+/// with bytes that do not correspond to its length. This struct fixes
+/// that so we can generate arbitrary addresses that don't fail equality
+/// after a roundtrip.
+#[derive(Clone, Debug)]
+pub struct ArbAddress(pub Address);
+
+impl Arbitrary for ArbAddress {
+    fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+        let addr = Address::arbitrary(g);
+        let bz = addr.to_bytes();
+        let addr = Address::from_bytes(&bz).expect("address roundtrip works");
+        Self(addr)
+    }
+}

--- a/ipld/resolver/src/behaviour/discovery.rs
+++ b/ipld/resolver/src/behaviour/discovery.rs
@@ -277,9 +277,9 @@ impl NetworkBehaviour for Behaviour {
                 // The Kademlia configuration should ensure that peers are added automatically to the bucket,
                 // without need for manual action, so this should be informational only.
                 // The only event which could be a warning is the `UnroutablePeer`; I don't fully understand
-                // under which conditions it can arise though. It might be a good idea to log that.
-                NetworkBehaviourAction::GenerateEvent(out) => {
-                    if let ev @ KademliaEvent::UnroutablePeer { .. } = out {
+                // under which conditions it can arise though, so let's log that one.
+                NetworkBehaviourAction::GenerateEvent(ev) => {
+                    if let KademliaEvent::UnroutablePeer { .. } = ev {
                         debug!("unexpected Kademlia event: {ev:?}")
                     }
                     continue;

--- a/ipld/resolver/src/behaviour/discovery.rs
+++ b/ipld/resolver/src/behaviour/discovery.rs
@@ -38,6 +38,13 @@ pub enum Event {
 
     /// Event emitted when the last connection to a peer is closed.
     Disconnected(PeerId, Vec<Multiaddr>),
+
+    /// Event emitted when a peer is added or updated in the routing table,
+    /// which means if we later ask for its addresses, they should be known.
+    Added(PeerId, Vec<Multiaddr>),
+
+    /// Event emitted when a peer is removed from the routing table.
+    Removed(PeerId),
 }
 
 /// `Discovery` behaviour configuration.
@@ -273,19 +280,38 @@ impl NetworkBehaviour for Behaviour {
         // Poll Kademlia.
         while let Poll::Ready(ev) = self.inner.poll(cx, params) {
             match ev {
-                // Not propagating Kademlia specific events, just the ones meant for the Swarm.
-                // The Kademlia configuration should ensure that peers are added automatically to the bucket,
-                // without need for manual action, so this should be informational only.
-                // The only event which could be a warning is the `UnroutablePeer`; I don't fully understand
-                // under which conditions it can arise though, so let's log that one.
                 NetworkBehaviourAction::GenerateEvent(ev) => {
-                    if let KademliaEvent::UnroutablePeer { .. } = ev {
-                        debug!("unexpected Kademlia event: {ev:?}")
+                    match ev {
+                        // Not expecting unroutable peers
+                        KademliaEvent::UnroutablePeer { .. } => {
+                            debug!("unexpected Kademlia event: {ev:?}")
+                        }
+                        // Information only.
+                        KademliaEvent::InboundRequest { .. }
+                        | KademliaEvent::OutboundQueryProgressed { .. } => {}
+                        // The config ensures peers are added to the table if there's room.
+                        // We're not emitting these as known peers because the address will probably not be returned by `addresses_of_peer`,
+                        // so the outside service would have to keep track, which is not what we want.
+                        KademliaEvent::PendingRoutablePeer { .. }
+                        | KademliaEvent::RoutablePeer { .. } => {}
+                        // This event should ensure that we will be able to answer address lookups later.
+                        KademliaEvent::RoutingUpdated {
+                            peer,
+                            addresses,
+                            old_peer,
+                            ..
+                        } => {
+                            // There are two events here; we can only return one, so let's defer them to the outbox.
+                            if let Some(peer_id) = old_peer {
+                                self.outbox.push_back(Event::Removed(peer_id))
+                            }
+                            self.outbox
+                                .push_back(Event::Added(peer, addresses.into_vec()))
+                        }
                     }
-                    continue;
                 }
                 other => {
-                    return Poll::Ready(other.map_out(|_| unreachable!("continue'd")));
+                    return Poll::Ready(other.map_out(|_| unreachable!("already handled")));
                 }
             }
         }

--- a/ipld/resolver/src/behaviour/membership.rs
+++ b/ipld/resolver/src/behaviour/membership.rs
@@ -1,6 +1,10 @@
 use std::task::Context;
 
+use fvm_ipld_encoding::serde::{Deserialize, Serialize};
+use ipc_sdk::subnet_id::SubnetID;
+use libipld::multihash;
 use libp2p::core::connection::ConnectionId;
+use libp2p::core::{signed_envelope, DecodeError, SignedEnvelope};
 use libp2p::swarm::derive_prelude::FromSwarm;
 use libp2p::swarm::{NetworkBehaviourAction, PollParameters};
 use libp2p::Multiaddr;
@@ -10,10 +14,82 @@ use libp2p::{
     PeerId,
 };
 
-// TODO: Add event when we learn about someone participating in a subnet.
-#[derive(Debug)]
-pub enum MembershipEvent {}
+const DOMAIN_SEP: &str = "ipc-membership";
+const PROVIDER_RECORD_PAYLOAD_TYPE: &str = "/ipc/provider-record";
 
+/// Unix timestamp in seconds since epoch, which we can use to select the
+/// more recent message during gossiping.
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+pub struct Timestamp(u64);
+
+/// Record of the ability to provide data from a list of subnets.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProviderRecord {
+    /// The ID of the peer we can contact to pull data from.
+    peer_id: PeerId,
+    /// The IDs of the subnets they are participating in.
+    subnet_ids: Vec<SubnetID>,
+    /// Timestamp from when the peer published this record.
+    ///
+    /// We use a timestamp instead of just a nonce so that we
+    /// can drop records which are too old, indicating that
+    /// the peer has dropped off.
+    timestamp: Timestamp,
+}
+
+/// A [`ProviderRecord`] with a [`SignedEnvelope`] proving that the
+/// peer indeed is ready to provide the data for the listed subnets.
+#[derive(Debug)]
+pub struct SignedProviderRecord {
+    /// The deserialized and validated [`ProviderRecord`].
+    record: ProviderRecord,
+    /// The [`SignedEnvelope`] from which the record was deserialized from.
+    envelope: SignedEnvelope,
+}
+
+// Based on `libp2p_core::peer_record::PeerRecord`
+impl SignedProviderRecord {
+    pub fn from_signed_envelope(envelope: SignedEnvelope) -> Result<Self, FromEnvelopeError> {
+        let (payload, signing_key) = envelope.payload_and_signing_key(
+            String::from(DOMAIN_SEP),
+            PROVIDER_RECORD_PAYLOAD_TYPE.as_bytes(),
+        )?;
+
+        let record = fvm_ipld_encoding::from_slice::<ProviderRecord>(payload)?;
+
+        if record.peer_id != signing_key.to_peer_id() {
+            return Err(FromEnvelopeError::MismatchedSignature);
+        }
+
+        Ok(Self { record, envelope })
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum FromEnvelopeError {
+    /// Failed to extract the payload from the envelope.
+    #[error("Failed to extract payload from envelope")]
+    BadPayload(#[from] signed_envelope::ReadPayloadError),
+    /// Failed to decode the provided bytes as a [`ProviderRecord`].
+    #[error("Failed to decode bytes as ProviderRecord")]
+    InvalidProviderRecord(#[from] fvm_ipld_encoding::Error),
+    /// Failed to decode the peer ID.
+    #[error("Failed to decode bytes as PeerId")]
+    InvalidPeerId(#[from] multihash::Error),
+    /// The signer of the envelope is different than the peer id in the record.
+    #[error("The signer of the envelope is different than the peer id in the record")]
+    MismatchedSignature,
+}
+
+/// Events emitted by the [`Membership`] behaviour.
+#[derive(Debug)]
+pub enum MembershipEvent {
+    /// Indicate that a given peer is able to serve data from a list of subnets.
+    SubnetProvider(SignedProviderRecord),
+}
+
+/// `Membership` is a [`NetworkBehaviour`] internally using [`Gossipsub`] to learn which
+/// peer is able to resolve CIDs in different subnets.
 pub struct Membership {
     inner: Gossipsub,
 }

--- a/ipld/resolver/src/behaviour/membership.rs
+++ b/ipld/resolver/src/behaviour/membership.rs
@@ -1,6 +1,10 @@
-use std::task::Context;
+use std::collections::{HashMap, VecDeque};
+use std::task::{Context, Poll};
 
+use ipc_sdk::subnet_id::SubnetID;
 use libp2p::core::connection::ConnectionId;
+use libp2p::gossipsub::{GossipsubEvent, GossipsubMessage, IdentTopic, Topic};
+use libp2p::identity::Keypair;
 use libp2p::swarm::derive_prelude::FromSwarm;
 use libp2p::swarm::{NetworkBehaviourAction, PollParameters};
 use libp2p::Multiaddr;
@@ -9,20 +13,115 @@ use libp2p::{
     swarm::{ConnectionHandler, IntoConnectionHandler, NetworkBehaviour},
     PeerId,
 };
+use log::debug;
+use tokio::time::Interval;
 
-use crate::provider_record::SignedProviderRecord;
+use crate::provider_record::{SignedProviderRecord, Timestamp};
+
+/// `Gossipsub` subnet membership topic identifier.
+const PUBSUB_MEMBERSHIP: &str = "/ipc/membership";
+
+struct Config {
+    /// Network name to be combined into the Gossipsub topic.
+    network_name: String,
+}
 
 /// Events emitted by the [`membership::Behaviour`] behaviour.
 #[derive(Debug)]
 pub enum Event {
     /// Indicate that a given peer is able to serve data from a list of subnets.
+    ///
+    /// Note that each the event contains the snapshot of the currently provided
+    /// subnets, not a delta. This means that if there were two peers using the
+    /// same keys running on different addresses, e.g. if the same operator ran
+    /// something supporting subnet A on one address, and another process supporting
+    /// subnet B on a different address, these would override each other, unless
+    /// they have different public keys (and thus peer IDs) associated with them.
+    ///
+    /// This should be okay, as in practice there is no significance to these
+    /// peer IDs, we can even generate a fresh key-pair every time we run the
+    /// resolver.
     SubnetProvider(SignedProviderRecord),
 }
 
 /// A [`NetworkBehaviour`] internally using [`Gossipsub`] to learn which
 /// peer is able to resolve CIDs in different subnets.
 pub struct Behaviour {
+    /// [`Gossipsub`] behaviour to spread the information about subnet membership.
     inner: Gossipsub,
+    /// Events to return when polled.
+    outbox: VecDeque<Event>,
+    /// [`Keypair`] used to construct [`SignedProviderRecord`] instances.
+    keypair: Keypair,
+    /// Name of the [`Gossipsub`] topic where subnet memberships are published.
+    membership_topic: IdentTopic, // Topic::new(format!("{}/{}", PUBSUB_MEMBERSHIP, network_name)
+    /// List of subnet IDs this agent is providing data for.
+    subnet_ids: Vec<SubnetID>,
+    /// List of peer IDs supporting each individual subnet.
+    ///
+    /// TODO: Limit the number of peers and topic we track. How do we limit the subnets?
+    /// An agent will probably only be asked to resolve topics from the current subnet and
+    /// its children, but how do we know which are legitimate child subnets?
+    ///
+    /// TODO: How do we protect against DoS attacks trying to fill the memory with bogus data?
+    /// We could differentiate by tracking which peers we are actually connected to, and first
+    /// prune the ones we just heard about, but we don't know if they are legit.
+    subnet_membership: HashMap<SubnetID, Vec<PeerId>>,
+    /// Timestamp of the last record received about a peer.
+    ///
+    /// TODO: Add more meta-data, such as whether the peer was connected to at any point in time,
+    /// or whether it served data to us.
+    peer_timestamps: HashMap<PeerId, Timestamp>,
+    /// Interval between publishing the currently supported subnets.
+    ///
+    /// This acts like a heartbeat; if a peer doesn't publish its snapshot for a long time,
+    /// other agents can prune it from their cache and not try to contact for resolution.
+    publish_interval: Interval,
+}
+
+impl Behaviour {
+    /// Set all the currently supported subnet IDs, then publish the updated list.
+    pub fn set_subnet_ids(&mut self, subnet_ids: Vec<SubnetID>) -> anyhow::Result<()> {
+        self.subnet_ids = subnet_ids;
+        self.publish_membership()
+    }
+
+    /// Add a subnet to the list of supported subnets, then publish the updated list.
+    pub fn add_subnet_id(&mut self, subnet_id: SubnetID) -> anyhow::Result<()> {
+        if self.subnet_ids.contains(&subnet_id) {
+            return Ok(());
+        }
+        self.subnet_ids.push(subnet_id);
+        self.publish_membership()
+    }
+
+    /// Remove a subnet from the list of supported subnets, then publish the updated list.
+    pub fn remove_subnet_id(&mut self, subnet_id: SubnetID) -> anyhow::Result<()> {
+        if !self.subnet_ids.contains(&subnet_id) {
+            return Ok(());
+        }
+        self.subnet_ids.retain(|id| id != &subnet_id);
+        self.publish_membership()
+    }
+
+    /// Send a message through Gossipsub to let everyone know about the current configuration.
+    fn publish_membership(&mut self) -> anyhow::Result<()> {
+        let record = SignedProviderRecord::new(&self.keypair, self.subnet_ids.clone())?;
+        let data = record.into_envelope().into_protobuf_encoding();
+        let _msg_id = self.inner.publish(self.membership_topic.clone(), data)?;
+        Ok(())
+    }
+
+    /// Remove any membership record that hasn't been updated for a long time.
+    fn prune_membership(&mut self) {}
+
+    /// Parse and handle a [`GossipsubMessage`]. If it's from the expected topic,
+    /// then raise domain event to let the rest of the application know about a
+    /// provider. Also update all the book keeping in the behaviour that we use
+    /// to answer future queries about the topic.
+    fn handle_message(&mut self, msg: GossipsubMessage) -> Option<Event> {
+        todo!()
+    }
 }
 
 impl NetworkBehaviour for Behaviour {
@@ -53,11 +152,57 @@ impl NetworkBehaviour for Behaviour {
 
     fn poll(
         &mut self,
-        _cx: &mut Context<'_>,
-        _params: &mut impl PollParameters,
+        cx: &mut Context<'_>,
+        params: &mut impl PollParameters,
     ) -> std::task::Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+        // Emit own events first.
+        if let Some(ev) = self.outbox.pop_front() {
+            return Poll::Ready(NetworkBehaviourAction::GenerateEvent(ev));
+        }
+
+        // Republish our current peer record snapshot and prune old records.
+        if self.publish_interval.poll_tick(cx).is_ready() {
+            self.publish_membership();
+            self.prune_membership();
+        }
+
         // Poll Gossipsub for events; this is where we can handle Gossipsub messages and
         // store the associations from peers to subnets.
-        todo!()
+        while let Poll::Ready(ev) = self.inner.poll(cx, params) {
+            match ev {
+                NetworkBehaviourAction::GenerateEvent(ev) => {
+                    match ev {
+                        // NOTE: We could (ab)use the Gossipsub mechanism itself to signal subnet membership,
+                        // however I think the information would only spread to our nearest neighbours we are
+                        // connected to. If we assume there are hundreds of agents in each subnet which may
+                        // or may not overlap, and each agent is connected to ~50 other agents, then the chance
+                        // that there are subnets from which there are no or just a few connections is not
+                        // insignificant. For this reason I oped to use messages instead, and let the content
+                        // carry the information, spreading through the Gossipsub network regardless of the
+                        // number of connected peers.
+                        GossipsubEvent::Subscribed { .. } | GossipsubEvent::Unsubscribed { .. } => {
+                        }
+                        // Log potential misconfiguration.
+                        GossipsubEvent::GossipsubNotSupported { peer_id } => {
+                            debug!("peer {peer_id} doesn't support gossipsub");
+                        }
+                        GossipsubEvent::Message {
+                            propagation_source,
+                            message_id,
+                            message,
+                        } => {
+                            if let Some(ev) = self.handle_message(message) {
+                                return Poll::Ready(NetworkBehaviourAction::GenerateEvent(ev));
+                            }
+                        }
+                    }
+                }
+                other => {
+                    return Poll::Ready(other.map_out(|_| unreachable!("already handled")));
+                }
+            }
+        }
+
+        Poll::Pending
     }
 }

--- a/ipld/resolver/src/behaviour/membership.rs
+++ b/ipld/resolver/src/behaviour/membership.rs
@@ -1,0 +1,56 @@
+use std::task::Context;
+
+use libp2p::core::connection::ConnectionId;
+use libp2p::swarm::derive_prelude::FromSwarm;
+use libp2p::swarm::{NetworkBehaviourAction, PollParameters};
+use libp2p::Multiaddr;
+use libp2p::{
+    gossipsub::Gossipsub,
+    swarm::{ConnectionHandler, IntoConnectionHandler, NetworkBehaviour},
+    PeerId,
+};
+
+// TODO: Add event when we learn about someone participating in a subnet.
+#[derive(Debug)]
+pub enum MembershipEvent {}
+
+pub struct Membership {
+    inner: Gossipsub,
+}
+
+impl NetworkBehaviour for Membership {
+    type ConnectionHandler = <Gossipsub as NetworkBehaviour>::ConnectionHandler;
+    type OutEvent = MembershipEvent;
+
+    fn new_handler(&mut self) -> Self::ConnectionHandler {
+        self.inner.new_handler()
+    }
+
+    fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        self.inner.addresses_of_peer(peer_id)
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {
+        self.inner.on_swarm_event(event)
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        event: <<Self::ConnectionHandler as IntoConnectionHandler>::Handler as ConnectionHandler>::OutEvent,
+    ) {
+        self.inner
+            .on_connection_handler_event(peer_id, connection_id, event)
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut Context<'_>,
+        _params: &mut impl PollParameters,
+    ) -> std::task::Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+        // Poll Gossipsub for events; this is where we can handle Gossipsub messages and
+        // store the associations from peers to subnets.
+        todo!()
+    }
+}

--- a/ipld/resolver/src/behaviour/mod.rs
+++ b/ipld/resolver/src/behaviour/mod.rs
@@ -1,8 +1,12 @@
 use libipld::store::StoreParams;
-use libp2p::{gossipsub::Gossipsub, identify, ping, swarm::NetworkBehaviour};
+use libp2p::{identify, ping, swarm::NetworkBehaviour};
 use libp2p_bitswap::Bitswap;
 
 mod discovery;
+mod membership;
+
+use self::discovery::Discovery;
+use self::membership::Membership;
 
 /// Libp2p behaviour to manage content resolution from other subnets, using:
 ///
@@ -14,8 +18,8 @@ pub struct IpldResolver<P: StoreParams> {
     ping: ping::Behaviour,
     identify: identify::Behaviour,
     discovery: discovery::Behaviour,
-    gossipsub: Gossipsub, // TODO (IPC-35): Wrap into Membership
-    bitswap: Bitswap<P>,  // TODO (IPC-36): Wrap into Resolve
+    membership: Membership,
+    bitswap: Bitswap<P>, // TODO (IPC-36): Wrap into Resolve
 }
 
 // Unfortunately by using `#[derive(NetworkBehaviour)]` we cannot easily inspects events

--- a/ipld/resolver/src/behaviour/mod.rs
+++ b/ipld/resolver/src/behaviour/mod.rs
@@ -5,8 +5,6 @@ use libp2p_bitswap::Bitswap;
 mod discovery;
 mod membership;
 
-use self::membership::Membership;
-
 /// Libp2p behaviour to manage content resolution from other subnets, using:
 ///
 /// * Kademlia for peer discovery
@@ -17,8 +15,8 @@ pub struct IpldResolver<P: StoreParams> {
     ping: ping::Behaviour,
     identify: identify::Behaviour,
     discovery: discovery::Behaviour,
-    membership: Membership,
-    bitswap: Bitswap<P>, // TODO (IPC-36): Wrap into Resolve
+    membership: membership::Behaviour,
+    bitswap: Bitswap<P>, // TODO (IPC-36): Wrap
 }
 
 // Unfortunately by using `#[derive(NetworkBehaviour)]` we cannot easily inspects events

--- a/ipld/resolver/src/behaviour/mod.rs
+++ b/ipld/resolver/src/behaviour/mod.rs
@@ -5,7 +5,6 @@ use libp2p_bitswap::Bitswap;
 mod discovery;
 mod membership;
 
-use self::discovery::Discovery;
 use self::membership::Membership;
 
 /// Libp2p behaviour to manage content resolution from other subnets, using:

--- a/ipld/resolver/src/lib.rs
+++ b/ipld/resolver/src/lib.rs
@@ -2,4 +2,6 @@
 #[allow(dead_code)]
 mod behaviour;
 #[allow(dead_code)]
+mod provider_record;
+#[allow(dead_code)]
 mod service;

--- a/ipld/resolver/src/lib.rs
+++ b/ipld/resolver/src/lib.rs
@@ -2,6 +2,8 @@
 #[allow(dead_code)]
 mod behaviour;
 #[allow(dead_code)]
+mod provider_cache;
+#[allow(dead_code)]
 mod provider_record;
 #[allow(dead_code)]
 mod service;

--- a/ipld/resolver/src/lib.rs
+++ b/ipld/resolver/src/lib.rs
@@ -5,3 +5,6 @@ mod behaviour;
 mod provider_record;
 #[allow(dead_code)]
 mod service;
+
+#[cfg(any(test, feature = "arb"))]
+mod arb;

--- a/ipld/resolver/src/provider_cache.rs
+++ b/ipld/resolver/src/provider_cache.rs
@@ -1,0 +1,125 @@
+use std::collections::{HashMap, HashSet};
+
+use ipc_sdk::subnet_id::SubnetID;
+use libp2p::PeerId;
+
+use crate::provider_record::{ProviderRecord, Timestamp};
+
+pub struct SubnetProviderCache {
+    /// Maximum number of subnets to track, to protect against DoS attacks, trying to
+    /// flood someone with subnets that don't actually exist. When the number of subnets
+    /// reaches this value, we remove the subnet with the smallest number of providers;
+    /// hopefully this would be a subnet
+    max_subnets: usize,
+    /// Set of peers with known addresses. Only such peers can be added to the cache.
+    routable_peers: HashSet<PeerId>,
+    /// List of peer IDs supporting each subnet.
+    subnet_providers: HashMap<SubnetID, HashSet<PeerId>>,
+    /// Timestamp of the last record received about a peer.
+    peer_timestamps: HashMap<PeerId, Timestamp>,
+}
+
+impl SubnetProviderCache {
+    pub fn new(max_subnets: usize) -> Self {
+        Self {
+            max_subnets,
+            routable_peers: Default::default(),
+            subnet_providers: Default::default(),
+            peer_timestamps: Default::default(),
+        }
+    }
+
+    /// Mark a peer as routable.
+    ///
+    /// Once routable, the cache will keep track of provided subnets.
+    pub fn set_routable(&mut self, peer_id: PeerId) {
+        self.routable_peers.insert(peer_id);
+    }
+
+    /// Mark a previously routable peer as unroutable.
+    ///
+    /// Once unroutable, the cache will stop tracking the provided subnets.
+    pub fn set_unroutable(&mut self, peer_id: PeerId) {
+        self.routable_peers.remove(&peer_id);
+        self.peer_timestamps.remove(&peer_id);
+        for providers in self.subnet_providers.values_mut() {
+            providers.remove(&peer_id);
+        }
+    }
+
+    /// Check if a peer has been marked as routable.
+    pub fn is_routable(&self, peer_id: PeerId) -> bool {
+        self.routable_peers.contains(&peer_id)
+    }
+
+    /// Try to add a provider to the cache.
+    ///
+    /// Return `true` if succeeded, `false` if the peer is not yet routable.
+    pub fn add_provider(&mut self, record: ProviderRecord) -> bool {
+        if !self.is_routable(record.peer_id) {
+            return false;
+        }
+
+        let timestamp = self
+            .peer_timestamps
+            .entry(record.peer_id)
+            .or_insert(record.timestamp);
+
+        if *timestamp < record.timestamp {
+            *timestamp = record.timestamp;
+            for subnet_id in record.subnet_ids {
+                let providers = self.subnet_providers.entry(subnet_id).or_default();
+                providers.insert(record.peer_id);
+            }
+            self.prune_subnets();
+        }
+
+        true
+    }
+
+    /// Ensure we don't have more than `max_subnets` number of subnets in the cache.
+    fn prune_subnets(&mut self) {
+        let to_prune = self.subnet_providers.len().saturating_sub(self.max_subnets);
+
+        if to_prune > 0 {
+            let mut counts = self
+                .subnet_providers
+                .iter()
+                .map(|(id, ps)| (id.clone(), ps.len()))
+                .collect::<Vec<_>>();
+
+            counts.sort_by_key(|(_, count)| *count);
+
+            for (subnet_id, _) in counts.into_iter().take(to_prune) {
+                self.subnet_providers.remove(&subnet_id);
+            }
+        }
+    }
+
+    /// Prune any provider which hasn't provided an update since a cutoff timestamp.
+    pub fn prune_providers(&mut self, cutoff_timestamp: Timestamp) {
+        let to_prune = self
+            .peer_timestamps
+            .iter()
+            .filter_map(|(id, ts)| {
+                if *ts < cutoff_timestamp {
+                    Some(*id)
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
+        for peer_id in to_prune {
+            self.set_unroutable(peer_id)
+        }
+    }
+
+    /// List any known providers of a subnet.
+    pub fn providers_of_subnet(&self, subnet_id: &SubnetID) -> Vec<PeerId> {
+        self.subnet_providers
+            .get(subnet_id)
+            .map(|hs| hs.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+}

--- a/ipld/resolver/src/provider_cache.rs
+++ b/ipld/resolver/src/provider_cache.rs
@@ -55,7 +55,7 @@ impl SubnetProviderCache {
     /// Try to add a provider to the cache.
     ///
     /// Return `true` if succeeded, `false` if the peer is not yet routable.
-    pub fn add_provider(&mut self, record: ProviderRecord) -> bool {
+    pub fn add_provider(&mut self, record: &ProviderRecord) -> bool {
         if !self.is_routable(record.peer_id) {
             return false;
         }
@@ -67,8 +67,8 @@ impl SubnetProviderCache {
 
         if *timestamp < record.timestamp {
             *timestamp = record.timestamp;
-            for subnet_id in record.subnet_ids {
-                let providers = self.subnet_providers.entry(subnet_id).or_default();
+            for subnet_id in record.subnet_ids.iter() {
+                let providers = self.subnet_providers.entry(subnet_id.clone()).or_default();
                 providers.insert(record.peer_id);
             }
             self.prune_subnets();

--- a/ipld/resolver/src/provider_record.rs
+++ b/ipld/resolver/src/provider_record.rs
@@ -108,12 +108,23 @@ impl SignedProviderRecord {
         Ok(Self { record, envelope })
     }
 
+    /// Deserialize then check the domain tags and the signature.
+    pub fn from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
+        let envelope = SignedEnvelope::from_protobuf_encoding(&bytes)?;
+        let signed_record = Self::from_signed_envelope(envelope)?;
+        Ok(signed_record)
+    }
+
     pub fn record(&self) -> &ProviderRecord {
         &self.record
     }
 
     pub fn envelope(&self) -> &SignedEnvelope {
         &self.envelope
+    }
+
+    pub fn into_record(self) -> ProviderRecord {
+        self.record
     }
 
     pub fn into_envelope(self) -> SignedEnvelope {

--- a/ipld/resolver/src/provider_record.rs
+++ b/ipld/resolver/src/provider_record.rs
@@ -1,0 +1,129 @@
+use std::time::SystemTime;
+
+use fvm_ipld_encoding::serde::{Deserialize, Serialize};
+use ipc_sdk::subnet_id::SubnetID;
+use libipld::multihash;
+use libp2p::core::{signed_envelope, SignedEnvelope};
+use libp2p::identity::Keypair;
+use libp2p::PeerId;
+
+const DOMAIN_SEP: &str = "ipc-membership";
+const PAYLOAD_TYPE: &str = "/ipc/provider-record";
+
+/// Unix timestamp in seconds since epoch, which we can use to select the
+/// more recent message during gossiping.
+#[derive(Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+pub struct Timestamp(u64);
+
+impl Timestamp {
+    /// Current timestamp.
+    pub fn now() -> Self {
+        let secs = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("now() is never before UNIX_EPOCH")
+            .as_secs();
+        Self(secs)
+    }
+
+    /// Seconds elapsed since Unix epoch.
+    pub fn as_secs(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Record of the ability to provide data from a list of subnets.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ProviderRecord {
+    /// The ID of the peer we can contact to pull data from.
+    peer_id: PeerId,
+    /// The IDs of the subnets they are participating in.
+    subnet_ids: Vec<SubnetID>,
+    /// Timestamp from when the peer published this record.
+    ///
+    /// We use a timestamp instead of just a nonce so that we
+    /// can drop records which are too old, indicating that
+    /// the peer has dropped off.
+    timestamp: Timestamp,
+}
+
+impl ProviderRecord {
+    pub fn peer_id(&self) -> PeerId {
+        self.peer_id
+    }
+    pub fn subnet_ids(&self) -> &[SubnetID] {
+        self.subnet_ids.as_slice()
+    }
+    pub fn timestamp(&self) -> Timestamp {
+        self.timestamp
+    }
+}
+
+/// A [`ProviderRecord`] with a [`SignedEnvelope`] proving that the
+/// peer indeed is ready to provide the data for the listed subnets.
+#[derive(Debug)]
+pub struct SignedProviderRecord {
+    /// The deserialized and validated [`ProviderRecord`].
+    record: ProviderRecord,
+    /// The [`SignedEnvelope`] from which the record was deserialized from.
+    envelope: SignedEnvelope,
+}
+
+// Based on `libp2p_core::peer_record::PeerRecord`
+impl SignedProviderRecord {
+    /// Create a new [`SignedProviderRecord`] with the current timestamp
+    /// and a signed envelope which can be shared with others.
+    pub fn new(key: &Keypair, subnet_ids: Vec<SubnetID>) -> anyhow::Result<Self> {
+        let timestamp = Timestamp::now();
+        let peer_id = key.public().to_peer_id();
+        let record = ProviderRecord {
+            peer_id,
+            subnet_ids,
+            timestamp,
+        };
+        let payload = fvm_ipld_encoding::to_vec(&record)?;
+        let envelope = SignedEnvelope::new(
+            key,
+            DOMAIN_SEP.to_owned(),
+            PAYLOAD_TYPE.as_bytes().to_vec(),
+            payload,
+        )?;
+        Ok(Self { record, envelope })
+    }
+
+    pub fn from_signed_envelope(envelope: SignedEnvelope) -> Result<Self, FromEnvelopeError> {
+        let (payload, signing_key) =
+            envelope.payload_and_signing_key(DOMAIN_SEP.to_owned(), PAYLOAD_TYPE.as_bytes())?;
+
+        let record = fvm_ipld_encoding::from_slice::<ProviderRecord>(payload)?;
+
+        if record.peer_id != signing_key.to_peer_id() {
+            return Err(FromEnvelopeError::MismatchedSignature);
+        }
+
+        Ok(Self { record, envelope })
+    }
+
+    pub fn record(&self) -> &ProviderRecord {
+        &self.record
+    }
+
+    pub fn envelope(&self) -> &SignedEnvelope {
+        &self.envelope
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum FromEnvelopeError {
+    /// Failed to extract the payload from the envelope.
+    #[error("Failed to extract payload from envelope")]
+    BadPayload(#[from] signed_envelope::ReadPayloadError),
+    /// Failed to decode the provided bytes as a [`ProviderRecord`].
+    #[error("Failed to decode bytes as ProviderRecord")]
+    InvalidProviderRecord(#[from] fvm_ipld_encoding::Error),
+    /// Failed to decode the peer ID.
+    #[error("Failed to decode bytes as PeerId")]
+    InvalidPeerId(#[from] multihash::Error),
+    /// The signer of the envelope is different than the peer id in the record.
+    #[error("The signer of the envelope is different than the peer id in the record")]
+    MismatchedSignature,
+}


### PR DESCRIPTION
Closes #35 

The PR adds:
* a `SignedProviderRecord` type that contains the current list of subnets a peer can provide data for
* a `SubnetProviderCache` type to keep track of who provides data for which subnet
* a `membership` module with a `Behaviour` wrapping a `Gossipsub` behaviour, publishing `SignedProviderRecord`s to the `/ipc/membership/<network-name>` topic.
* `Added` and `Removed` variants to `discovery::Event` which signals that we know about an address for a peer

The idea is that everyone periodically publishes which subnets they can be contacted about to resolve content, in the form of these signed provider records, to provide tamper resistance (e.g. nobody can route traffic to some peer by altering their records and adding subnets to them). However, the records do not contain addresses, only peer IDs. The addresses are expected to be learned by the discovery module, which presumably makes some efforts to make sure these are valid and reachable addresses, and also takes care of limiting how many addresses we are tracking, so a Byzantine member cannot conjure up millions of fake addresses and keys to overwhelm everybody else and crowd out honest participants. Once the discovery module publishes the new `Added` event and the membership module is told about it, it will cache the subnet memberships and keep them cached as long as regular heartbeats are provided, in the form of records with newer timestamps. The timestamps also protect against replay attacks by not replacing newer records with older ones.

TODO:
- [ ] Config

