### PR TITLE
IPC-35: Config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2414,6 +2414,7 @@ name = "ipc_ipld_resolver"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "blake2b_simd",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 3.0.0-alpha.17",
  "ipc-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ thiserror = "1.0"
 tokio = { version = "1.16", features = ["full"] }
 quickcheck = "1"
 quickcheck_macros = "1"
-
+blake2b_simd = "1.0"
 
 fvm_ipld_encoding = "0.3"
 fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -10,6 +10,7 @@ license-file.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+blake2b_simd = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 libp2p = { version = "0.50", default-features = false, features = [

--- a/ipld/resolver/src/behaviour/discovery.rs
+++ b/ipld/resolver/src/behaviour/discovery.rs
@@ -25,7 +25,6 @@ use libp2p::{
     Multiaddr, PeerId,
 };
 use log::debug;
-use thiserror::Error;
 use tokio::time::Interval;
 
 // NOTE: The Discovery behaviour is largely based on what exists in Forest. If it ain't broken...
@@ -63,7 +62,7 @@ pub struct Config {
     network_name: String,
 }
 
-#[derive(Error, Debug)]
+#[derive(thiserror::Error, Debug)]
 pub enum ConfigError {
     #[error("invalid network: {0}")]
     InvalidNetwork(String),
@@ -92,7 +91,7 @@ impl ConfigBuilder {
     }
 
     /// Set the number of active connections at which we pause discovery.
-    pub fn with_max_connections(&mut self, limit: usize) -> &mut Self {
+    pub fn with_target_connections(&mut self, limit: usize) -> &mut Self {
         self.0.target_connections = limit;
         self
     }

--- a/ipld/resolver/src/behaviour/discovery.rs
+++ b/ipld/resolver/src/behaviour/discovery.rs
@@ -112,7 +112,7 @@ impl Behaviour {
 
         let kademlia_opt = if dc.enable_kademlia {
             let mut kad_config = KademliaConfig::default();
-            let protocol_name = format!("/ipc/kad/{}/kad/1.0.0", nc.network_name);
+            let protocol_name = format!("/ipc/{}/kad/1.0.0", nc.network_name);
             kad_config.set_protocol_names(vec![Cow::Owned(protocol_name.as_bytes().to_vec())]);
 
             let store = MemoryStore::new(nc.local_peer_id());

--- a/ipld/resolver/src/behaviour/membership.rs
+++ b/ipld/resolver/src/behaviour/membership.rs
@@ -139,13 +139,13 @@ impl Behaviour {
     }
 
     /// Set all the currently supported subnet IDs, then publish the updated list.
-    pub fn set_subnet_ids(&mut self, subnet_ids: Vec<SubnetID>) -> anyhow::Result<()> {
+    pub fn set_provided_subnets(&mut self, subnet_ids: Vec<SubnetID>) -> anyhow::Result<()> {
         self.subnet_ids = subnet_ids;
         self.publish_membership()
     }
 
     /// Add a subnet to the list of supported subnets, then publish the updated list.
-    pub fn add_subnet_id(&mut self, subnet_id: SubnetID) -> anyhow::Result<()> {
+    pub fn add_provided_subnet(&mut self, subnet_id: SubnetID) -> anyhow::Result<()> {
         if self.subnet_ids.contains(&subnet_id) {
             return Ok(());
         }
@@ -154,7 +154,7 @@ impl Behaviour {
     }
 
     /// Remove a subnet from the list of supported subnets, then publish the updated list.
-    pub fn remove_subnet_id(&mut self, subnet_id: SubnetID) -> anyhow::Result<()> {
+    pub fn remove_provided_subnet(&mut self, subnet_id: SubnetID) -> anyhow::Result<()> {
         if !self.subnet_ids.contains(&subnet_id) {
             return Ok(());
         }

--- a/ipld/resolver/src/behaviour/membership.rs
+++ b/ipld/resolver/src/behaviour/membership.rs
@@ -120,7 +120,7 @@ impl Behaviour {
                 scoring::build_peer_score_params(membership_topic.clone()),
                 scoring::build_peer_score_thresholds(),
             )
-            .map_err(|s| ConfigError::InvalidGossipsubConfig(s.into()))?;
+            .map_err(ConfigError::InvalidGossipsubConfig)?;
 
         // Don't publish immediately, it's empty. Let the creator call `set_subnet_ids` to trigger initially.
         let mut interval = tokio::time::interval(mc.publish_interval);

--- a/ipld/resolver/src/behaviour/mod.rs
+++ b/ipld/resolver/src/behaviour/mod.rs
@@ -1,11 +1,33 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 use libipld::store::StoreParams;
-use libp2p::{identify, ping, swarm::NetworkBehaviour};
+use libp2p::{
+    identify,
+    identity::{Keypair, PublicKey},
+    ping,
+    swarm::NetworkBehaviour,
+    PeerId,
+};
 use libp2p_bitswap::Bitswap;
 
 mod discovery;
 mod membership;
+
+pub struct NetworkConfig {
+    /// Cryptographic key used to sign messages.
+    pub local_key: Keypair,
+    /// Network name to be differentiate this peer group.
+    pub network_name: String,
+}
+
+impl NetworkConfig {
+    pub fn local_public_key(&self) -> PublicKey {
+        self.local_key.public()
+    }
+    pub fn local_peer_id(&self) -> PeerId {
+        self.local_public_key().to_peer_id()
+    }
+}
 
 /// Libp2p behaviour to manage content resolution from other subnets, using:
 ///

--- a/ipld/resolver/src/hash.rs
+++ b/ipld/resolver/src/hash.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 

--- a/ipld/resolver/src/hash.rs
+++ b/ipld/resolver/src/hash.rs
@@ -1,0 +1,39 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use blake2b_simd::Params;
+
+/// Generates BLAKE2b hash of fixed 32 bytes size.
+///
+/// # Example
+/// ```
+/// use forest_encoding::blake2b_256;
+///
+/// let ingest: Vec<u8> = vec![];
+/// let hash = blake2b_256(&ingest);
+/// assert_eq!(hash.len(), 32);
+/// ```
+pub fn blake2b_256(ingest: &[u8]) -> [u8; 32] {
+    let digest = Params::new()
+        .hash_length(32)
+        .to_state()
+        .update(ingest)
+        .finalize();
+
+    let mut ret = [0u8; 32];
+    ret.clone_from_slice(digest.as_bytes());
+    ret
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vector_hashing() {
+        let ing_vec = vec![1, 2, 3];
+
+        assert_eq!(blake2b_256(&ing_vec), blake2b_256(&[1, 2, 3]));
+        assert_ne!(blake2b_256(&ing_vec), blake2b_256(&[1, 2, 3, 4]));
+    }
+}

--- a/ipld/resolver/src/hash.rs
+++ b/ipld/resolver/src/hash.rs
@@ -4,15 +4,6 @@
 use blake2b_simd::Params;
 
 /// Generates BLAKE2b hash of fixed 32 bytes size.
-///
-/// # Example
-/// ```
-/// use forest_encoding::blake2b_256;
-///
-/// let ingest: Vec<u8> = vec![];
-/// let hash = blake2b_256(&ingest);
-/// assert_eq!(hash.len(), 32);
-/// ```
 pub fn blake2b_256(ingest: &[u8]) -> [u8; 32] {
     let digest = Params::new()
         .hash_length(32)

--- a/ipld/resolver/src/lib.rs
+++ b/ipld/resolver/src/lib.rs
@@ -12,3 +12,5 @@ mod service;
 
 #[cfg(any(test, feature = "arb"))]
 mod arb;
+
+mod hash;

--- a/ipld/resolver/src/provider_cache.rs
+++ b/ipld/resolver/src/provider_cache.rs
@@ -328,10 +328,10 @@ mod tests {
             cache.add_provider(&record);
         }
 
-        if !cache.subnet_providers.contains_key(&subnets[0]) {
+        if !cache.subnet_providers.contains_key(subnets[0]) {
             return Err("static subnet not found".into());
         }
-        if !cache.subnet_providers.contains_key(&subnets[1]) {
+        if !cache.subnet_providers.contains_key(subnets[1]) {
             return Err("pinned subnet not found".into());
         }
         Ok(())


### PR DESCRIPTION
Closes #35 

Follow up to #44, this PR adds configuration to the `membership` module and refactors the `discovery` module to get rid of the `ConfigBuilder` and extract common configuration fields into a `NetworkConfig`. 

It also adds `pin_subnet` methods to the `Behaviour` and the `SubnetProviderCache`, which can be used to let the module know about the existence of some known subnet IDs that it should never prune from the cache. This is to prevent attackers trying to throw tons of random subnets at us and prevent us from overcoming their numbers and learn who to resolve the content of real subnets from.

The reason I removed the builder is because I found having to repeat fields 3 times (`Config`, `ConfigBuilder` and `Behaviour`) annoying, and in the end it still wasn't enough to nicely prevent the `Behaviour::new` from having to return a `Result`, or else do `expect` and potentially panic. Since this is meant to be a library, that's not nice. It's easier to just embrace the fact that `new` does validation. We can still do our best to validate the configuration after we read it from files.
