### PR TITLE
IPC-36: Content behaviour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2415,6 +2415,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blake2b_simd",
+ "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 3.0.0-alpha.17",
  "ipc-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ quickcheck = "1"
 quickcheck_macros = "1"
 blake2b_simd = "1.0"
 
+fvm_ipld_blockstore = "0.1"
 fvm_ipld_encoding = "0.3"
 fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -39,6 +39,7 @@ quickcheck = { workspace = true, optional = true }
 ipc-sdk = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true, optional = true }
+fvm_ipld_blockstore = { workspace = true, optional = true }
 
 [dev-dependencies]
 quickcheck = { workspace = true }
@@ -47,5 +48,6 @@ fvm_shared = { workspace = true, features = ["arb"] }
 
 
 [features]
-default = ["arb"]
+default = ["arb", "missing_blocks"]
 arb = ["quickcheck", "fvm_shared/arb"]
+missing_blocks = ["fvm_ipld_blockstore"]

--- a/ipld/resolver/src/behaviour/content.rs
+++ b/ipld/resolver/src/behaviour/content.rs
@@ -1,0 +1,126 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
+
+use std::task::{Context, Poll};
+
+use libipld::{store::StoreParams, Cid};
+use libp2p::{
+    swarm::{
+        derive_prelude::{ConnectionId, FromSwarm},
+        ConnectionHandler, IntoConnectionHandler, NetworkBehaviour, NetworkBehaviourAction,
+        PollParameters,
+    },
+    Multiaddr, PeerId,
+};
+use libp2p_bitswap::{Bitswap, BitswapConfig, BitswapEvent, BitswapStore, QueryId};
+
+// Not much to do here, just hiding the `Progress` event as I don't think we'll need it.
+// We can't really turn it into anything more meaningful; the outer Service, which drives
+// the Swarm events, will have to store the `QueryId` and figure out which CID it was about
+// (there could be multiple queries running over the same CID) and how to respond to the
+// original requestor (e.g. by completing a channel).
+#[derive(Debug)]
+pub enum Event {
+    /// Event raised when a resolution request is finished.
+    ///
+    /// The result will indicate either success, or arbitrary failure.
+    /// If it is a success, the CID can be found in the [`BitswapStore`]
+    /// instance the behaviour was created with.
+    ///
+    /// Note that it is possible that the synchronization completed
+    /// partially, but some recursive constituent is missing. The
+    /// caller can use the [`missing_blocks`] function to check
+    /// whether a retry is necessary.
+    Complete(QueryId, anyhow::Result<()>),
+}
+
+/// Behaviour built on [`Bitswap`] to resolve IPLD content from [`Cid`] to raw bytes.
+pub struct Behaviour<P: StoreParams> {
+    inner: Bitswap<P>,
+}
+
+impl<P: StoreParams> Behaviour<P> {
+    pub fn new<S>(store: S) -> Self
+    where
+        S: BitswapStore<Params = P>,
+    {
+        let bitswap = Bitswap::new(BitswapConfig::default(), store);
+        // TODO: `bitswap.register_metrics(prometheus::default_registry())`
+        Self { inner: bitswap }
+    }
+
+    /// Recursively resolve a [`Cid`] and all underlying CIDs into blocks.
+    ///
+    /// The [`Bitswap`] behaviour will call the [`BitswapStore`] to ask for
+    /// blocks which are missing, ie. find CIDs which aren't available locally.
+    /// It is up to the store implementation to decide which links need to be
+    /// followed.
+    ///
+    /// It is also up to the store implementation to decide which CIDs requests
+    /// to responds to, e.g. if we only want to resolve certain type of content,
+    /// then the store can look up in a restricted collection, rather than the
+    /// full IPLD store.
+    ///
+    /// Resolution will be attempted from the peers passed to the method,
+    /// starting with the first one with `WANT-BLOCK`, then whoever responds
+    /// positively to `WANT-HAVE` requests. The caller should talk to the
+    /// `membership::Behaviour` first to find suitable peers, and then
+    /// prioritise peers which are connected.
+    ///
+    /// The underlying [`libp2p_request_response::RequestResponse`] behaviour
+    /// will initiate connections to the peers which aren't connected at the moment.
+    pub fn resolve(&mut self, cid: Cid, peers: Vec<PeerId>) -> QueryId {
+        // Not passing any missing items, which will result in a call to `BitswapStore::missing_blocks`.
+        self.inner.sync(cid, peers, [].into_iter())
+    }
+}
+
+impl<P: StoreParams> NetworkBehaviour for Behaviour<P> {
+    type ConnectionHandler = <Bitswap<P> as NetworkBehaviour>::ConnectionHandler;
+    type OutEvent = Event;
+
+    fn new_handler(&mut self) -> Self::ConnectionHandler {
+        self.inner.new_handler()
+    }
+
+    fn addresses_of_peer(&mut self, peer_id: &PeerId) -> Vec<Multiaddr> {
+        self.inner.addresses_of_peer(peer_id)
+    }
+
+    fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {
+        self.inner.on_swarm_event(event)
+    }
+
+    fn on_connection_handler_event(
+        &mut self,
+        peer_id: PeerId,
+        connection_id: ConnectionId,
+        event: <<Self::ConnectionHandler as IntoConnectionHandler>::Handler as ConnectionHandler>::OutEvent,
+    ) {
+        self.inner
+            .on_connection_handler_event(peer_id, connection_id, event)
+    }
+
+    fn poll(
+        &mut self,
+        cx: &mut Context<'_>,
+        params: &mut impl PollParameters,
+    ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
+        while let Poll::Ready(ev) = self.inner.poll(cx, params) {
+            match ev {
+                NetworkBehaviourAction::GenerateEvent(ev) => match ev {
+                    BitswapEvent::Progress(_, _) => {}
+                    BitswapEvent::Complete(id, result) => {
+                        let out = Event::Complete(id, result);
+                        return Poll::Ready(NetworkBehaviourAction::GenerateEvent(out));
+                    }
+                },
+                other => {
+                    return Poll::Ready(other.map_out(|_| unreachable!("already handled")));
+                }
+            }
+        }
+
+        Poll::Pending
+    }
+}

--- a/ipld/resolver/src/behaviour/mod.rs
+++ b/ipld/resolver/src/behaviour/mod.rs
@@ -8,8 +8,8 @@ use libp2p::{
     swarm::NetworkBehaviour,
     PeerId,
 };
-use libp2p_bitswap::Bitswap;
 
+mod content;
 mod discovery;
 mod membership;
 
@@ -40,7 +40,7 @@ pub struct IpldResolver<P: StoreParams> {
     identify: identify::Behaviour,
     discovery: discovery::Behaviour,
     membership: membership::Behaviour,
-    bitswap: Bitswap<P>, // TODO (IPC-36): Wrap
+    bitswap: content::Behaviour<P>,
 }
 
 // Unfortunately by using `#[derive(NetworkBehaviour)]` we cannot easily inspects events

--- a/ipld/resolver/src/lib.rs
+++ b/ipld/resolver/src/lib.rs
@@ -14,3 +14,6 @@ mod service;
 mod arb;
 
 mod hash;
+
+#[cfg(feature = "missing_blocks")]
+pub mod missing_blocks;

--- a/ipld/resolver/src/missing_blocks.rs
+++ b/ipld/resolver/src/missing_blocks.rs
@@ -1,0 +1,31 @@
+// Copyright 2019-2022 ChainSafe Systems
+// SPDX-License-Identifier: Apache-2.0, MIT
+
+use fvm_ipld_blockstore::Blockstore;
+use libipld::Cid;
+use libipld::{prelude::*, store::StoreParams, Ipld};
+
+/// Recursively find all [`Cid`] fields in the [`Block`] structures stored in the
+/// [`Blockstore`] and return all CIDs which could *not* be retrieved from the store.
+///
+/// This function is available as a convenience, to be used by any [`BitswapStore`]
+/// implementation as they see fit.
+pub fn missing_blocks<BS: Blockstore, P: StoreParams>(
+    bs: &mut BS,
+    cid: &Cid,
+) -> anyhow::Result<Vec<Cid>>
+where
+    Ipld: References<<P as StoreParams>::Codecs>,
+{
+    let mut stack = vec![*cid];
+    let mut missing = vec![];
+    while let Some(cid) = stack.pop() {
+        if let Some(data) = bs.get(&cid)? {
+            let block = libipld::Block::<P>::new_unchecked(cid, data);
+            block.references(&mut stack)?;
+        } else {
+            missing.push(cid);
+        }
+    }
+    Ok(missing)
+}

--- a/ipld/resolver/src/missing_blocks.rs
+++ b/ipld/resolver/src/missing_blocks.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
 // Copyright 2019-2022 ChainSafe Systems
 // SPDX-License-Identifier: Apache-2.0, MIT
 


### PR DESCRIPTION
Closes #36 

The PR adds a `content::Behaviour` that wraps `Bitswap` and adds the `resolve` method to recursively retrieve a tree of CIDs.

This is a small PR, as it turns out there's not much to be done over Bitswap, it's mostly just comments and calling the right method the right way for what we're trying to achieve. All the book-keeping will have to happen further up in the #37 

A potential extension could be to pass not just a list of peers, but a list of connected peers and a list of known, but unconnected peers as well, and then make two queries: try with the connected ones first, then the unconnected, or use up to N combined in the first try, etc. This can also be done in the service, though, as separate queries, but we could add a separate `QueryId` to this behaviour and manage it inside. Currently the most straight forward way is to pass all peers which serve a subnet and let Bitswap connect to them at will. I thought we might want to keep it simple to start with and optimise later. EDIT: This optimisation has been implemented in #55 

I copied the `missing_blocks` method from Forest, think it will be handy and I already investigated how it works, it's cool. It's behind a feature flag, in case the agent wants to resolve CIDs in a more controlled fashion. 

Another probably necessary extension would be to manage outgoing connections, close them down once they aren't needed - maybe `libp2p-bitswap` is doing this already (it has a keep-alive setting), need to check. Created an issue for this: https://github.com/consensus-shipyard/ipc-agent/issues/57