### PR TITLE
IPC-37: Resolver Service and Client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -415,6 +415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-vec"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b4ff8b16e6076c3e14220b39fbc1fabb6737522281a388998046859400895f"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,6 +479,15 @@ name = "block-padding"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+
+[[package]]
+name = "bloom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d00ac8e5056d6d65376a3c1aa5c7c34850d6949ace17f0266953a254eb3d6fe8"
+dependencies = [
+ "bit-vec",
+]
 
 [[package]]
 name = "bs58"
@@ -2415,6 +2430,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "blake2b_simd",
+ "bloom",
  "fvm_ipld_blockstore",
  "fvm_ipld_encoding 0.3.3",
  "fvm_shared 3.0.0-alpha.17",

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -11,6 +11,7 @@ license-file.workspace = true
 [dependencies]
 anyhow = { workspace = true }
 blake2b_simd = { workspace = true }
+bloom = "0.3"
 thiserror = { workspace = true }
 tokio = { workspace = true }
 libp2p = { version = "0.50", default-features = false, features = [

--- a/ipld/resolver/src/behaviour/content.rs
+++ b/ipld/resolver/src/behaviour/content.rs
@@ -12,7 +12,9 @@ use libp2p::{
     },
     Multiaddr, PeerId,
 };
-use libp2p_bitswap::{Bitswap, BitswapConfig, BitswapEvent, BitswapStore, QueryId};
+use libp2p_bitswap::{Bitswap, BitswapConfig, BitswapEvent, BitswapStore};
+
+pub type QueryId = libp2p_bitswap::QueryId;
 
 // Not much to do here, just hiding the `Progress` event as I don't think we'll need it.
 // We can't really turn it into anything more meaningful; the outer Service, which drives

--- a/ipld/resolver/src/behaviour/membership.rs
+++ b/ipld/resolver/src/behaviour/membership.rs
@@ -178,6 +178,11 @@ impl Behaviour {
         self.provider_cache.pin_subnet(subnet_id)
     }
 
+    /// Make a subnet pruneable.
+    pub fn unpin_subnet(&mut self, subnet_id: &SubnetID) {
+        self.provider_cache.unpin_subnet(subnet_id)
+    }
+
     /// Send a message through Gossipsub to let everyone know about the current configuration.
     fn publish_membership(&mut self) -> anyhow::Result<()> {
         let record = SignedProviderRecord::new(&self.local_key, self.subnet_ids.clone())?;

--- a/ipld/resolver/src/behaviour/membership.rs
+++ b/ipld/resolver/src/behaviour/membership.rs
@@ -36,7 +36,7 @@ const PUBSUB_MEMBERSHIP: &str = "/ipc/membership";
 #[derive(Debug)]
 pub enum Event {
     /// Indicate a change in the subnets a peer is known to support.
-    Updated((PeerId, ProviderDelta)),
+    Updated(PeerId, ProviderDelta),
 
     /// Indicate that we no longer treat a peer as routable and removed all their supported subnet associations.
     Removed(PeerId),
@@ -218,7 +218,7 @@ impl Behaviour {
                 Ok(record) => match self.provider_cache.add_provider(&record) {
                     None => return Some(Event::Skipped(record.peer_id)),
                     Some(d) if d.is_empty() => return None,
-                    Some(d) => return Some(Event::Updated((record.peer_id, d))),
+                    Some(d) => return Some(Event::Updated(record.peer_id, d)),
                 },
                 Err(e) => {
                     warn!(

--- a/ipld/resolver/src/behaviour/mod.rs
+++ b/ipld/resolver/src/behaviour/mod.rs
@@ -8,11 +8,16 @@ use libp2p::{
     swarm::NetworkBehaviour,
     PeerId,
 };
+use libp2p_bitswap::BitswapStore;
 
 mod content;
 mod discovery;
 mod membership;
 
+pub use discovery::Config as DiscoveryConfig;
+pub use membership::Config as MembershipConfig;
+
+#[derive(Clone, Debug)]
 pub struct NetworkConfig {
     /// Cryptographic key used to sign messages.
     pub local_key: Keypair,
@@ -29,22 +34,53 @@ impl NetworkConfig {
     }
 }
 
-/// Libp2p behaviour to manage content resolution from other subnets, using:
+#[derive(thiserror::Error, Debug)]
+pub enum ConfigError {
+    #[error("Error in the discovery configuration")]
+    Discovery(#[from] discovery::ConfigError),
+    #[error("Error in the membership configuration")]
+    Membership(#[from] membership::ConfigError),
+}
+
+/// Libp2p behaviour bundle to manage content resolution from other subnets, using:
 ///
 /// * Kademlia for peer discovery
 /// * Gossipsub to advertise subnet membership
 /// * Bitswap to resolve CIDs
 #[derive(NetworkBehaviour)]
-pub struct IpldResolver<P: StoreParams> {
+pub struct Behaviour<P: StoreParams> {
     ping: ping::Behaviour,
     identify: identify::Behaviour,
     discovery: discovery::Behaviour,
     membership: membership::Behaviour,
-    bitswap: content::Behaviour<P>,
+    content: content::Behaviour<P>,
 }
 
 // Unfortunately by using `#[derive(NetworkBehaviour)]` we cannot easily inspects events
 // from the inner behaviours, e.g. we cannot poll a behaviour and if it returns something
-// of interest then call a method on another behaviour. We can do this in another wrapper
+// of interest then call a method on another behaviour. We can do this in the a wrapper
 // where we manually implement `NetworkBehaviour`, or the outer service where we drive the
 // Swarm; there we are free to call any of the behaviours.
+
+impl<P: StoreParams> Behaviour<P> {
+    pub fn new<S>(
+        nc: NetworkConfig,
+        dc: DiscoveryConfig,
+        mc: MembershipConfig,
+        store: S,
+    ) -> Result<Self, ConfigError>
+    where
+        S: BitswapStore<Params = P>,
+    {
+        Ok(Self {
+            ping: Default::default(),
+            identify: identify::Behaviour::new(identify::Config::new(
+                "ipfs/0.1.0".into(),
+                nc.local_public_key(),
+            )),
+            discovery: discovery::Behaviour::new(nc.clone(), dc)?,
+            membership: membership::Behaviour::new(nc, mc)?,
+            content: content::Behaviour::new(store),
+        })
+    }
+}

--- a/ipld/resolver/src/behaviour/mod.rs
+++ b/ipld/resolver/src/behaviour/mod.rs
@@ -58,9 +58,9 @@ pub struct Behaviour<P: StoreParams> {
 
 // Unfortunately by using `#[derive(NetworkBehaviour)]` we cannot easily inspects events
 // from the inner behaviours, e.g. we cannot poll a behaviour and if it returns something
-// of interest then call a method on another behaviour. We can do this in the a wrapper
+// of interest then call a method on another behaviour. We can do this in yet another wrapper
 // where we manually implement `NetworkBehaviour`, or the outer service where we drive the
-// Swarm; there we are free to call any of the behaviours.
+// Swarm; there we are free to call any of the behaviours as well as the Swarm.
 
 impl<P: StoreParams> Behaviour<P> {
     pub fn new<S>(

--- a/ipld/resolver/src/behaviour/mod.rs
+++ b/ipld/resolver/src/behaviour/mod.rs
@@ -10,9 +10,9 @@ use libp2p::{
 };
 use libp2p_bitswap::BitswapStore;
 
-mod content;
-mod discovery;
-mod membership;
+pub mod content;
+pub mod discovery;
+pub mod membership;
 
 pub use discovery::Config as DiscoveryConfig;
 pub use membership::Config as MembershipConfig;
@@ -82,5 +82,17 @@ impl<P: StoreParams> Behaviour<P> {
             membership: membership::Behaviour::new(nc, mc)?,
             content: content::Behaviour::new(store),
         })
+    }
+
+    pub fn discovery_mut(&mut self) -> &mut discovery::Behaviour {
+        &mut self.discovery
+    }
+
+    pub fn membership_mut(&mut self) -> &mut membership::Behaviour {
+        &mut self.membership
+    }
+
+    pub fn content_mut(&mut self) -> &mut content::Behaviour<P> {
+        &mut self.content
     }
 }

--- a/ipld/resolver/src/lib.rs
+++ b/ipld/resolver/src/lib.rs
@@ -1,19 +1,16 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
-// TODO (IPC-38): Remove dead code allowances.
-#[allow(dead_code)]
 mod behaviour;
-#[allow(dead_code)]
+mod hash;
 mod provider_cache;
-#[allow(dead_code)]
 mod provider_record;
-#[allow(dead_code)]
 mod service;
 
 #[cfg(any(test, feature = "arb"))]
 mod arb;
 
-mod hash;
-
 #[cfg(feature = "missing_blocks")]
 pub mod missing_blocks;
+
+pub use behaviour::{DiscoveryConfig, MembershipConfig};
+pub use service::{Client, Config, ConnectionConfig, NoKnownPeers, Service};

--- a/ipld/resolver/src/provider_record.rs
+++ b/ipld/resolver/src/provider_record.rs
@@ -38,7 +38,7 @@ impl Sub<Duration> for Timestamp {
     type Output = Self;
 
     fn sub(self, rhs: Duration) -> Self {
-        Self(self.0.saturating_sub(rhs.as_secs()))
+        Self(self.as_secs().saturating_sub(rhs.as_secs()))
     }
 }
 
@@ -46,7 +46,7 @@ impl Add<Duration> for Timestamp {
     type Output = Self;
 
     fn add(self, rhs: Duration) -> Self {
-        Self(self.0.saturating_add(rhs.as_secs()))
+        Self(self.as_secs().saturating_add(rhs.as_secs()))
     }
 }
 
@@ -128,14 +128,6 @@ impl SignedProviderRecord {
         Ok(signed_record)
     }
 
-    pub fn record(&self) -> &ProviderRecord {
-        &self.record
-    }
-
-    pub fn envelope(&self) -> &SignedEnvelope {
-        &self.envelope
-    }
-
     pub fn into_record(self) -> ProviderRecord {
         self.record
     }
@@ -206,7 +198,7 @@ mod tests {
 
     #[quickcheck]
     fn prop_roundtrip(signed_record: SignedProviderRecord) -> bool {
-        let envelope_bytes = signed_record.envelope().clone().into_protobuf_encoding();
+        let envelope_bytes = signed_record.envelope.into_protobuf_encoding();
 
         let envelope =
             SignedEnvelope::from_protobuf_encoding(&envelope_bytes).expect("envelope roundtrip");
@@ -219,7 +211,7 @@ mod tests {
 
     #[quickcheck]
     fn prop_tamper_proof(signed_record: SignedProviderRecord, idx: usize) -> bool {
-        let mut envelope_bytes = signed_record.envelope().clone().into_protobuf_encoding();
+        let mut envelope_bytes = signed_record.envelope.into_protobuf_encoding();
         // Do some kind of mutation to a random byte in the envelope; after that it should not validate.
         let idx = idx % envelope_bytes.len();
         envelope_bytes[idx] = u8::MAX - envelope_bytes[idx];

--- a/ipld/resolver/src/service.rs
+++ b/ipld/resolver/src/service.rs
@@ -76,17 +76,20 @@ pub struct Client {
 }
 
 impl Client {
+    /// Send a request to the [`Service`], unless it has stopped listening.
     fn send_request(&self, req: Request) -> anyhow::Result<()> {
         self.request_tx
             .send(req)
             .map_err(|_| anyhow!("disconnected"))
     }
 
+    /// Set the complete list of subnets currently supported by this node.
     pub fn set_provided_subnets(&self, subnet_ids: Vec<SubnetID>) -> anyhow::Result<()> {
         let req = Request::SetProvidedSubnets(subnet_ids);
         self.send_request(req)
     }
 
+    /// Add a list of subnets we know really exist and we are interested in them.
     pub fn pin_subnets(&self, subnet_ids: Vec<SubnetID>) -> anyhow::Result<()> {
         let req = Request::PinSubnets(subnet_ids);
         self.send_request(req)
@@ -344,6 +347,7 @@ impl<P: StoreParams> Service<P> {
     }
 }
 
+/// Respond to the sender of the query, if they are still listening.
 fn send_resolve_result(tx: Sender<ResolveResult>, res: ResolveResult) {
     if tx.send(res).is_err() {
         error!("error sending resolve result; listener closed")

--- a/ipld/resolver/src/service.rs
+++ b/ipld/resolver/src/service.rs
@@ -1,17 +1,100 @@
+use std::time::Duration;
+
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 use libipld::store::StoreParams;
-use libp2p::Swarm;
+use libp2p::{
+    core::{muxing::StreamMuxerBox, transport::Boxed},
+    identity::Keypair,
+    mplex, noise,
+    swarm::{ConnectionLimits, SwarmBuilder},
+    yamux, Multiaddr, PeerId, Swarm, Transport,
+};
+use libp2p_bitswap::BitswapStore;
 
-use crate::behaviour::IpldResolver;
+use crate::behaviour::{Behaviour, ConfigError, DiscoveryConfig, MembershipConfig, NetworkConfig};
+
+pub struct ConnectionConfig {
+    /// The address where we will listen to incoming connections.
+    listen_addr: Multiaddr,
+    /// Maximum number of incoming connections.
+    max_incoming: u32,
+}
+
+pub struct Config {
+    network: NetworkConfig,
+    discovery: DiscoveryConfig,
+    membership: MembershipConfig,
+    connection: ConnectionConfig,
+}
 
 pub struct IpldResolverService<P: StoreParams> {
-    swarm: Swarm<IpldResolver<P>>,
+    swarm: Swarm<Behaviour<P>>,
 }
 
 impl<P: StoreParams> IpldResolverService<P> {
+    pub fn new<S>(config: Config, store: S) -> Result<Self, ConfigError>
+    where
+        S: BitswapStore<Params = P>,
+    {
+        let peer_id = config.network.local_peer_id();
+        let transport = build_transport(config.network.local_key.clone());
+        let behaviour = Behaviour::new(config.network, config.discovery, config.membership, store)?;
+
+        // NOTE: Hardcoded values from Forest. Will leave them as is until we know we need to change.
+
+        let limits = ConnectionLimits::default()
+            .with_max_pending_incoming(Some(10))
+            .with_max_pending_outgoing(Some(30))
+            .with_max_established_incoming(Some(config.connection.max_incoming))
+            .with_max_established_outgoing(None) // Allow bitswap to connect to subnets we did not anticipate when we started.
+            .with_max_established_per_peer(Some(5));
+
+        let swarm = SwarmBuilder::with_tokio_executor(transport, behaviour, peer_id)
+            .connection_limits(limits)
+            .notify_handler_buffer_size(std::num::NonZeroUsize::new(20).expect("Not zero"))
+            .connection_event_buffer_size(64)
+            .build();
+
+        Ok(Self { swarm })
+    }
+
     /// Start the swarm listening for incoming connections and drive the events forward.
     pub async fn run(self) -> anyhow::Result<()> {
         todo!("IPC-37")
     }
+}
+
+/// Builds the transport stack that libp2p will communicate over.
+///
+/// Based on the equivalent in Forest.
+pub fn build_transport(local_key: Keypair) -> Boxed<(PeerId, StreamMuxerBox)> {
+    let tcp_transport =
+        || libp2p::tcp::tokio::Transport::new(libp2p::tcp::Config::new().nodelay(true));
+    let transport = libp2p::dns::TokioDnsConfig::system(tcp_transport()).unwrap();
+    let auth_config = {
+        let dh_keys = noise::Keypair::<noise::X25519Spec>::new()
+            .into_authentic(&local_key)
+            .expect("Noise key generation failed");
+
+        noise::NoiseConfig::xx(dh_keys).into_authenticated()
+    };
+
+    let mplex_config = {
+        let mut mplex_config = mplex::MplexConfig::new();
+        mplex_config.set_max_buffer_size(usize::MAX);
+
+        let mut yamux_config = yamux::YamuxConfig::default();
+        yamux_config.set_max_buffer_size(16 * 1024 * 1024);
+        yamux_config.set_receive_window_size(16 * 1024 * 1024);
+        // yamux_config.set_window_update_mode(WindowUpdateMode::OnRead);
+        libp2p::core::upgrade::SelectUpgrade::new(yamux_config, mplex_config)
+    };
+
+    transport
+        .upgrade(libp2p::core::upgrade::Version::V1)
+        .authenticate(auth_config)
+        .multiplex(mplex_config)
+        .timeout(Duration::from_secs(20))
+        .boxed()
 }


### PR DESCRIPTION
Closes #37 

The PR creates a `Service` and `Client` to act as the public interface of content resolution. 

The `Service` is what users of the library have to instantiate, it creates all the behaviours created in #34 , #35 and #36 , along with a `Client`, which can be used to send requests/commands to it over a channel. The `Client` can be cloned, so that a separate instance can be given to any component that needs to talk to the `Service`. 

Instead of an request/response queue as in Forest, the `Client` hides the query behind an async `resolve` method. The caller needs to tell which CID they want to resolve and from which subnet. The `Service` returns an error immediately if there are no peers known in that subnet.

The other two methods at the moment are to set a list of subnets the agent can provide data for, and to pin subnets which have known IDs (from config or from the ledger). Both take a list, but the first overrides any current value, the second adds to them.