### PR TITLE
Adds JSON-RPC method calls to read the state of the IPC actors and a convenience method to construct a LotusJsonRPCClient from a subnet config.

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,7 +7,7 @@
 
 mod deserialize;
 mod server;
-mod subnet;
+pub mod subnet;
 
 use std::collections::HashMap;
 use std::fs;

--- a/src/lotus/client.rs
+++ b/src/lotus/client.rs
@@ -307,10 +307,7 @@ impl LotusJsonRPCClient<JsonRpcClientImpl> {
     /// `LotusJsonRPCClient` makes requests to the URL defined in the `Subnet`.
     pub(crate) fn from_subnet(subnet: &Subnet) -> Self {
         let url = subnet.jsonrpc_api_http.clone();
-        let auth_token = match &subnet.auth_token {
-            None => None,
-            Some(token) => Some(token.as_str()),
-        };
+        let auth_token = subnet.auth_token.as_ref().map(|token| token.as_str());
         let jsonrpc_client = JsonRpcClientImpl::new(url, auth_token);
         LotusJsonRPCClient::new(jsonrpc_client)
     }

--- a/src/lotus/client.rs
+++ b/src/lotus/client.rs
@@ -307,7 +307,7 @@ impl LotusJsonRPCClient<JsonRpcClientImpl> {
     /// `LotusJsonRPCClient` makes requests to the URL defined in the `Subnet`.
     pub(crate) fn from_subnet(subnet: &Subnet) -> Self {
         let url = subnet.jsonrpc_api_http.clone();
-        let auth_token = subnet.auth_token.as_ref().map(|token| token.as_str());
+        let auth_token = subnet.auth_token.as_deref();
         let jsonrpc_client = JsonRpcClientImpl::new(url, auth_token);
         LotusJsonRPCClient::new(jsonrpc_client)
     }

--- a/src/lotus/client.rs
+++ b/src/lotus/client.rs
@@ -305,6 +305,7 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
 impl LotusJsonRPCClient<JsonRpcClientImpl> {
     /// A constructor that returns a `LotusJsonRPCClient` from a `Subnet`. The returned
     /// `LotusJsonRPCClient` makes requests to the URL defined in the `Subnet`.
+    #[allow(dead_code)]
     pub(crate) fn from_subnet(subnet: &Subnet) -> Self {
         let url = subnet.jsonrpc_api_http.clone();
         let auth_token = subnet.auth_token.as_deref();

--- a/src/lotus/client.rs
+++ b/src/lotus/client.rs
@@ -19,7 +19,10 @@ use serde_json::json;
 use crate::config::Subnet;
 use crate::jsonrpc::{JsonRpcClient, JsonRpcClientImpl, NO_PARAMS};
 use crate::lotus::message::chain::ChainHeadResponse;
-use crate::lotus::message::ipc::{IPCGetPrevCheckpointForChildResponse, IPCReadGatewayStateResponse, IPCReadSubnetActorStateResponse};
+use crate::lotus::message::ipc::{
+    IPCGetPrevCheckpointForChildResponse, IPCReadGatewayStateResponse,
+    IPCReadSubnetActorStateResponse,
+};
 use crate::lotus::message::mpool::{
     MpoolPushMessage, MpoolPushMessageResponse, MpoolPushMessageResponseInner,
 };
@@ -283,11 +286,17 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
         Ok(r)
     }
 
-    async fn ipc_read_subnet_actor_state(&self, tip_set: Cid) -> Result<IPCReadSubnetActorStateResponse> {
+    async fn ipc_read_subnet_actor_state(
+        &self,
+        tip_set: Cid,
+    ) -> Result<IPCReadSubnetActorStateResponse> {
         let params = json!([GATEWAY_ACTOR_ADDRESS, [CIDMap::from(tip_set)]]);
         let r = self
             .client
-            .request::<IPCReadSubnetActorStateResponse>(methods::IPC_READ_SUBNET_ACTOR_STATE, params)
+            .request::<IPCReadSubnetActorStateResponse>(
+                methods::IPC_READ_SUBNET_ACTOR_STATE,
+                params,
+            )
             .await?;
         Ok(r)
     }

--- a/src/lotus/client.rs
+++ b/src/lotus/client.rs
@@ -16,9 +16,10 @@ use num_traits::cast::ToPrimitive;
 use serde::de::DeserializeOwned;
 use serde_json::json;
 
-use crate::jsonrpc::{JsonRpcClient, NO_PARAMS};
+use crate::config::Subnet;
+use crate::jsonrpc::{JsonRpcClient, JsonRpcClientImpl, NO_PARAMS};
 use crate::lotus::message::chain::ChainHeadResponse;
-use crate::lotus::message::ipc::IPCGetPrevCheckpointForChildResponse;
+use crate::lotus::message::ipc::{IPCGetPrevCheckpointForChildResponse, IPCReadGatewayStateResponse, IPCReadSubnetActorStateResponse};
 use crate::lotus::message::mpool::{
     MpoolPushMessage, MpoolPushMessageResponse, MpoolPushMessageResponseInner,
 };
@@ -41,6 +42,8 @@ mod methods {
     pub const CHAIN_HEAD: &str = "Filecoin.ChainHead";
     pub const IPC_GET_PREV_CHECKPOINT_FOR_CHILD: &str = "Filecoin.IPCGetPrevCheckpointForChild";
     pub const IPC_GET_CHECKPOINT_TEMPLATE: &str = "Filecoin.IPCGetCheckpointTemplate";
+    pub const IPC_READ_GATEWAY_STATE: &str = "Filecoin.IPCReadGatewayState";
+    pub const IPC_READ_SUBNET_ACTOR_STATE: &str = "Filecoin.IPCReadSubnetActorState";
 }
 
 /// The default gateway actor address
@@ -269,5 +272,37 @@ impl<T: JsonRpcClient + Send + Sync> LotusClient for LotusJsonRPCClient<T> {
             )
             .await?;
         Ok(r)
+    }
+
+    async fn ipc_read_gateway_state(&self, tip_set: Cid) -> Result<IPCReadGatewayStateResponse> {
+        let params = json!([GATEWAY_ACTOR_ADDRESS, [CIDMap::from(tip_set)]]);
+        let r = self
+            .client
+            .request::<IPCReadGatewayStateResponse>(methods::IPC_READ_GATEWAY_STATE, params)
+            .await?;
+        Ok(r)
+    }
+
+    async fn ipc_read_subnet_actor_state(&self, tip_set: Cid) -> Result<IPCReadSubnetActorStateResponse> {
+        let params = json!([GATEWAY_ACTOR_ADDRESS, [CIDMap::from(tip_set)]]);
+        let r = self
+            .client
+            .request::<IPCReadSubnetActorStateResponse>(methods::IPC_READ_SUBNET_ACTOR_STATE, params)
+            .await?;
+        Ok(r)
+    }
+}
+
+impl LotusJsonRPCClient<JsonRpcClientImpl> {
+    /// A constructor that returns a `LotusJsonRPCClient` from a `Subnet`. The returned
+    /// `LotusJsonRPCClient` makes requests to the URL defined in the `Subnet`.
+    pub(crate) fn from_subnet(subnet: &Subnet) -> Self {
+        let url = subnet.jsonrpc_api_http.clone();
+        let auth_token = match &subnet.auth_token {
+            None => None,
+            Some(token) => Some(token.as_str()),
+        };
+        let jsonrpc_client = JsonRpcClientImpl::new(url, auth_token);
+        LotusJsonRPCClient::new(jsonrpc_client)
     }
 }

--- a/src/lotus/message/ipc.rs
+++ b/src/lotus/message/ipc.rs
@@ -13,12 +13,16 @@ pub struct IPCGetPrevCheckpointForChildResponse {
     pub cid: CIDMap,
 }
 
+/// The state of a gateway actor. The struct omits all fields that are not relevant for the
+/// execution of the IPC agent.
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct IPCReadGatewayStateResponse {
     pub check_period: ChainEpoch,
 }
 
+/// The state of a subnet actor. The struct omits all fields that are not relevant for the
+/// execution of the IPC agent.
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct IPCReadSubnetActorStateResponse {

--- a/src/lotus/message/ipc.rs
+++ b/src/lotus/message/ipc.rs
@@ -1,5 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
+use fvm_shared::clock::ChainEpoch;
+use ipc_subnet_actor::Validator;
 use serde::Deserialize;
 
 use crate::lotus::message::CIDMap;
@@ -9,4 +11,17 @@ use crate::lotus::message::CIDMap;
 pub struct IPCGetPrevCheckpointForChildResponse {
     #[serde(rename = "CID")]
     pub cid: CIDMap,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+pub struct IPCReadGatewayStateResponse {
+    pub check_period: ChainEpoch,
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+pub struct IPCReadSubnetActorStateResponse {
+    pub check_period: ChainEpoch,
+    pub validator_set: Vec<Validator>,
 }

--- a/src/lotus/mod.rs
+++ b/src/lotus/mod.rs
@@ -18,7 +18,7 @@ use message::mpool::{MpoolPushMessage, MpoolPushMessageResponseInner};
 use message::state::{ReadStateResponse, StateWaitMsgResponse};
 use message::wallet::{WalletKeyType, WalletListResponse};
 
-use crate::lotus::message::ipc::IPCGetPrevCheckpointForChildResponse;
+use crate::lotus::message::ipc::{IPCGetPrevCheckpointForChildResponse, IPCReadGatewayStateResponse, IPCReadSubnetActorStateResponse};
 
 pub mod client;
 pub mod message;
@@ -78,5 +78,12 @@ pub trait LotusClient {
         child_subnet_id: SubnetID,
     ) -> Result<IPCGetPrevCheckpointForChildResponse>;
 
+    /// Returns the checkpoint template at `epoch`.
     async fn ipc_get_checkpoint_template(&self, epoch: ChainEpoch) -> Result<Checkpoint>;
+
+    /// Returns the state of the gateway actor at `tip_set`.
+    async fn ipc_read_gateway_state(&self, tip_set: Cid) -> Result<IPCReadGatewayStateResponse>;
+
+    /// Returns the state of the subnet actor at `tip_set`.
+    async fn ipc_read_subnet_actor_state(&self, tip_set: Cid) -> Result<IPCReadSubnetActorStateResponse>;
 }

--- a/src/lotus/mod.rs
+++ b/src/lotus/mod.rs
@@ -18,7 +18,10 @@ use message::mpool::{MpoolPushMessage, MpoolPushMessageResponseInner};
 use message::state::{ReadStateResponse, StateWaitMsgResponse};
 use message::wallet::{WalletKeyType, WalletListResponse};
 
-use crate::lotus::message::ipc::{IPCGetPrevCheckpointForChildResponse, IPCReadGatewayStateResponse, IPCReadSubnetActorStateResponse};
+use crate::lotus::message::ipc::{
+    IPCGetPrevCheckpointForChildResponse, IPCReadGatewayStateResponse,
+    IPCReadSubnetActorStateResponse,
+};
 
 pub mod client;
 pub mod message;
@@ -85,5 +88,8 @@ pub trait LotusClient {
     async fn ipc_read_gateway_state(&self, tip_set: Cid) -> Result<IPCReadGatewayStateResponse>;
 
     /// Returns the state of the subnet actor at `tip_set`.
-    async fn ipc_read_subnet_actor_state(&self, tip_set: Cid) -> Result<IPCReadSubnetActorStateResponse>;
+    async fn ipc_read_subnet_actor_state(
+        &self,
+        tip_set: Cid,
+    ) -> Result<IPCReadSubnetActorStateResponse>;
 }


### PR DESCRIPTION
The two method calls are `ipc_read_gateway_state` and `ipc_read_subnet_actor_state`. This PR is part of a stack where the following one (#61) adds the checkpointing logic.
