### PR TITLE
Reload config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
  "serde_json",
  "serde_tuple",
  "strum",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-tungstenite 0.18.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ ipc-subnet-actor = { workspace = true }
 ipc-gateway = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 
+[dev-dependencies]
+tempfile = "3.4.0"
+
 [workspace.dependencies]
 anyhow = "1.0"
 thiserror = "1.0"

--- a/src/cli/commands/daemon.rs
+++ b/src/cli/commands/daemon.rs
@@ -7,7 +7,6 @@ use clap::Args;
 use std::fmt::Debug;
 
 use crate::cli::CommandLineHandler;
-use crate::config::Config;
 use crate::server::jsonrpc::JsonRPCServer;
 
 /// The command to start the ipc agent json rpc server in the foreground.
@@ -22,9 +21,8 @@ impl CommandLineHandler for LaunchDaemon {
 
         log::debug!("launching json rpc server with args: {:?}", arguments);
 
-        let config = Config::from_file(&arguments.config_file)?;
-        let server = JsonRPCServer::new(config);
-        server.run().await;
+        let server = JsonRPCServer::from_config_path(&arguments.config_file)?;
+        server.run().await?;
 
         Ok(())
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,14 +6,19 @@
 //! [`Config`] struct.
 
 mod deserialize;
+mod reload;
 mod server;
 mod subnet;
+
+#[cfg(test)]
+mod tests;
 
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
+pub use reload::ReloadableConfig;
 use serde::Deserialize;
 pub use server::Server;
 pub use server::JSON_RPC_ENDPOINT;
@@ -43,92 +48,10 @@ impl Config {
         let config: Config = Config::from_toml_str(contents.as_str())?;
         Ok(config)
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use std::net::SocketAddr;
-    use std::str::FromStr;
-
-    use fvm_shared::address::Address;
-    use indoc::formatdoc;
-    use ipc_sdk::subnet_id::{SubnetID, ROOTNET_ID};
-    use url::Url;
-
-    use crate::config::Config;
-
-    // Arguments for the config's fields
-    const SERVER_JSON_RPC_ADDR: &str = "127.0.0.1:3030";
-    const ROOT_ID: &str = "/root";
-    const CHILD_ID: &str = "/root/f0100";
-    const ROOT_AUTH_TOKEN: &str = "ROOT_AUTH_TOKEN";
-    const CHILD_AUTH_TOKEN: &str = "CHILD_AUTH_TOKEN";
-    const JSONRPC_API_HTTP: &str = "https://example.org/rpc/v0";
-    const JSONRPC_API_WS: &str = "ws://example.org/rpc/v0";
-    const ACCOUNT_ADDRESS: &str =
-        "f3thgjtvoi65yzdcoifgqh6utjbaod3ukidxrx34heu34d6avx6z7r5766t5jqt42a44ehzcnw3u5ehz47n42a";
-
-    #[test]
-    fn check_server_config() {
-        let config = read_config().server;
-        assert_eq!(
-            config.json_rpc_address,
-            SocketAddr::from_str(SERVER_JSON_RPC_ADDR).unwrap(),
-            "invalid server rpc address"
-        );
-    }
-
-    #[test]
-    fn check_subnets_config() {
-        let config = read_config().subnets;
-
-        let root = &config["root"];
-        assert_eq!(root.id, *ROOTNET_ID);
-        assert_eq!(
-            root.jsonrpc_api_http,
-            Url::from_str(JSONRPC_API_HTTP).unwrap()
-        );
-        assert_eq!(
-            root.jsonrpc_api_ws.as_ref().unwrap(),
-            &Url::from_str(JSONRPC_API_WS).unwrap()
-        );
-        assert_eq!(root.auth_token.as_ref().unwrap(), ROOT_AUTH_TOKEN);
-
-        let child = &config["child"];
-        assert_eq!(child.id, SubnetID::from_str(CHILD_ID).unwrap(),);
-        assert_eq!(
-            child.jsonrpc_api_http,
-            Url::from_str(JSONRPC_API_HTTP).unwrap(),
-        );
-        assert_eq!(child.auth_token.as_ref().unwrap(), CHILD_AUTH_TOKEN,);
-        assert_eq!(
-            child.accounts.as_ref(),
-            vec![Address::from_str(ACCOUNT_ADDRESS).unwrap()],
-        );
-    }
-
-    fn read_config() -> Config {
-        let config_str = formatdoc!(
-            r#"
-            [server]
-            json_rpc_address = "{SERVER_JSON_RPC_ADDR}"
-
-            [subnets]
-
-            [subnets.root]
-            id = "{ROOT_ID}"
-            jsonrpc_api_http = "{JSONRPC_API_HTTP}"
-            jsonrpc_api_ws = "{JSONRPC_API_WS}"
-            auth_token = "{ROOT_AUTH_TOKEN}"
-
-            [subnets.child]
-            id = "{CHILD_ID}"
-            jsonrpc_api_http = "{JSONRPC_API_HTTP}"
-            auth_token = "{CHILD_AUTH_TOKEN}"
-            accounts = ["{ACCOUNT_ADDRESS}"]
-        "#
-        );
-
-        Config::from_toml_str(config_str.as_str()).unwrap()
+    /// Reads a TOML configuration file specified in the `path` and returns a [`Config`] struct.
+    pub async fn from_file_async(path: impl AsRef<Path>) -> Result<Self> {
+        let contents = tokio::fs::read_to_string(path).await?;
+        Config::from_toml_str(contents.as_str())
     }
 }

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
 //! Reloadable config
 
 use crate::config::Config;

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -3,27 +3,15 @@
 //! Reloadable config
 
 use crate::config::Config;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use std::ops::DerefMut;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
-use tokio::sync::{broadcast, mpsc, oneshot};
-
-/// Internal request for reloadable config
-#[derive(Debug)]
-enum Request {
-    Reload {
-        response_tx: oneshot::Sender<Result<()>>,
-        path: String,
-    },
-    Stop,
-}
+use tokio::sync::broadcast;
 
 /// Reloadable configuration.
 pub struct ReloadableConfig {
     config: Arc<RwLock<Arc<Config>>>,
-    request_tx: mpsc::Sender<Request>,
-
     broadcast_tx: broadcast::Sender<()>,
     #[allow(dead_code)]
     broadcast_rx: broadcast::Receiver<()>,
@@ -33,46 +21,12 @@ impl ReloadableConfig {
     pub fn new(path: impl AsRef<Path>) -> Result<Self> {
         // we dont really need a big channel, the frequency should be very very low
         let channel_size = 8;
-        let (request_tx, mut request_rx) = mpsc::channel(channel_size);
         let (broadcast_tx, broadcast_rx) = broadcast::channel(channel_size);
 
         let config = Arc::new(RwLock::new(Arc::new(Config::from_file(path)?)));
-        let config_cloned = config.clone();
-        let broadcast_tx_cloned = broadcast_tx.clone();
-        tokio::spawn(async move {
-            while let Some(request) = request_rx.recv().await {
-                match request {
-                    Request::Reload { response_tx, path } => {
-                        let c = match Config::from_file_async(path).await {
-                            Ok(c) => c,
-                            Err(e) => {
-                                log::error!("cannot reload config due to: {e:?}");
-                                // we dont really care about if the other side is still listening
-                                response_tx
-                                    .send(Err(anyhow!("cannot reload config")))
-                                    .unwrap_or_default();
-                                continue;
-                            }
-                        };
-
-                        let mut config = config_cloned.write().unwrap();
-                        let r = config.deref_mut();
-                        *r = Arc::new(c);
-
-                        response_tx.send(Ok(())).unwrap_or_default();
-                        broadcast_tx_cloned.send(()).unwrap_or_default();
-                    }
-                    Request::Stop => {
-                        break;
-                    }
-                }
-            }
-            log::info!("config reloading exited");
-        });
 
         Ok(Self {
             config,
-            request_tx,
             broadcast_tx,
             broadcast_rx,
         })
@@ -86,19 +40,14 @@ impl ReloadableConfig {
 
     /// Triggers a reload of the config from the target path
     pub async fn reload(&self, path: String) -> Result<()> {
-        let (response_tx, rx) = oneshot::channel();
+        let new_config = Config::from_file_async(path).await?;
 
-        self.request_tx
-            .send(Request::Reload { response_tx, path })
-            .await?;
+        let mut config = self.config.write().unwrap();
+        let r = config.deref_mut();
+        *r = Arc::new(new_config);
 
-        rx.await?
-    }
+        self.broadcast_tx.send(()).unwrap_or_default();
 
-    /// Stops the reloading of config. Once this is called, `reload` will no longer trigger reloading.
-    pub async fn stop_reloading(&self) -> Result<()> {
-        let request = Request::Stop;
-        self.request_tx.send(request).await?;
         Ok(())
     }
 

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -11,8 +11,9 @@ use tokio::sync::broadcast;
 
 /// Reloadable configuration.
 pub struct ReloadableConfig {
-    config: Arc<RwLock<Arc<Config>>>,
+    config: RwLock<Arc<Config>>,
     broadcast_tx: broadcast::Sender<()>,
+    /// We keep at least one channel active, so that we dont encounter a `SendError`. We might need to use it later.
     #[allow(dead_code)]
     broadcast_rx: broadcast::Receiver<()>,
 }
@@ -20,10 +21,9 @@ pub struct ReloadableConfig {
 impl ReloadableConfig {
     pub fn new(path: impl AsRef<Path>) -> Result<Self> {
         // we dont really need a big channel, the frequency should be very very low
-        let channel_size = 8;
-        let (broadcast_tx, broadcast_rx) = broadcast::channel(channel_size);
+        let (broadcast_tx, broadcast_rx) = broadcast::channel(8);
 
-        let config = Arc::new(RwLock::new(Arc::new(Config::from_file(path)?)));
+        let config = RwLock::new(Arc::new(Config::from_file(path)?));
 
         Ok(Self {
             config,

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -1,0 +1,106 @@
+//! Reloadable config
+
+use crate::config::Config;
+use anyhow::{anyhow, Result};
+use std::ops::DerefMut;
+use std::path::Path;
+use std::sync::{Arc, RwLock};
+use tokio::sync::{broadcast, mpsc, oneshot};
+
+/// Internal request for reloadable config
+#[derive(Debug)]
+enum Request {
+    Reload {
+        response_tx: oneshot::Sender<Result<()>>,
+        path: String,
+    },
+    Stop,
+}
+
+/// Reloadable configuration.
+pub struct ReloadableConfig {
+    config: Arc<RwLock<Arc<Config>>>,
+    request_tx: mpsc::Sender<Request>,
+
+    broadcast_tx: broadcast::Sender<()>,
+    #[allow(dead_code)]
+    broadcast_rx: broadcast::Receiver<()>,
+}
+
+impl ReloadableConfig {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+        // we dont really need a big channel, the frequency should be very very low
+        let channel_size = 8;
+        let (request_tx, mut request_rx) = mpsc::channel(channel_size);
+        let (broadcast_tx, broadcast_rx) = broadcast::channel(channel_size);
+
+        let config = Arc::new(RwLock::new(Arc::new(Config::from_file(path)?)));
+        let config_cloned = config.clone();
+        let broadcast_tx_cloned = broadcast_tx.clone();
+        tokio::spawn(async move {
+            while let Some(request) = request_rx.recv().await {
+                match request {
+                    Request::Reload { response_tx, path } => {
+                        let c = match Config::from_file_async(path).await {
+                            Ok(c) => c,
+                            Err(e) => {
+                                log::error!("cannot reload config due to: {e:?}");
+                                // we dont really care about if the other side is still listening
+                                response_tx
+                                    .send(Err(anyhow!("cannot reload config")))
+                                    .unwrap_or_default();
+                                continue;
+                            }
+                        };
+
+                        let mut config = config_cloned.write().unwrap();
+                        let r = config.deref_mut();
+                        *r = Arc::new(c);
+
+                        response_tx.send(Ok(())).unwrap_or_default();
+                        broadcast_tx_cloned.send(()).unwrap_or_default();
+                    }
+                    Request::Stop => {
+                        break;
+                    }
+                }
+            }
+            log::info!("config reloading exited");
+        });
+
+        Ok(Self {
+            config,
+            request_tx,
+            broadcast_tx,
+            broadcast_rx,
+        })
+    }
+
+    /// Read from the config file.
+    pub fn get_config(&self) -> Arc<Config> {
+        let config = self.config.read().unwrap();
+        config.clone()
+    }
+
+    /// Triggers a reload of the config from the target path
+    pub async fn reload(&self, path: String) -> Result<()> {
+        let (response_tx, rx) = oneshot::channel();
+
+        self.request_tx
+            .send(Request::Reload { response_tx, path })
+            .await?;
+
+        rx.await?
+    }
+
+    /// Stops the reloading of config. Once this is called, `reload` will no longer trigger reloading.
+    pub async fn stop_reloading(&self) -> Result<()> {
+        let request = Request::Stop;
+        self.request_tx.send(request).await?;
+        Ok(())
+    }
+
+    pub fn new_subscriber(&self) -> broadcast::Receiver<()> {
+        self.broadcast_tx.subscribe()
+    }
+}

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -9,7 +9,10 @@ use std::path::Path;
 use std::sync::{Arc, RwLock};
 use tokio::sync::broadcast;
 
-/// Reloadable configuration.
+/// Reloadable configuration exposes the latest config through `get_config` method. Use this you
+/// will always the latest config. At the same time, it also exposes `new_subscriber`. If caller
+/// needs to be notified when config has updated, just make a new subscription. Once received a
+/// notification, read the config again to obtain the latest config.
 pub struct ReloadableConfig {
     config: RwLock<Arc<Config>>,
     broadcast_tx: broadcast::Sender<()>,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,0 +1,182 @@
+use std::io::Write;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::{Arc, Condvar, Mutex};
+
+use fvm_shared::address::Address;
+use indoc::formatdoc;
+use ipc_sdk::subnet_id::{SubnetID, ROOTNET_ID};
+use tempfile::NamedTempFile;
+use url::Url;
+
+use crate::config::{Config, ReloadableConfig};
+
+// Arguments for the config's fields
+const SERVER_JSON_RPC_ADDR: &str = "127.0.0.1:3030";
+const ROOT_ID: &str = "/root";
+const CHILD_ID: &str = "/root/f0100";
+const ROOT_AUTH_TOKEN: &str = "ROOT_AUTH_TOKEN";
+const CHILD_AUTH_TOKEN: &str = "CHILD_AUTH_TOKEN";
+const JSONRPC_API_HTTP: &str = "https://example.org/rpc/v0";
+const JSONRPC_API_WS: &str = "ws://example.org/rpc/v0";
+const ACCOUNT_ADDRESS: &str =
+    "f3thgjtvoi65yzdcoifgqh6utjbaod3ukidxrx34heu34d6avx6z7r5766t5jqt42a44ehzcnw3u5ehz47n42a";
+
+#[tokio::test]
+async fn reload_works() {
+    let config_str = config_str();
+
+    let mut file = NamedTempFile::new().unwrap();
+    let path = file
+        .path()
+        .as_os_str()
+        .to_os_string()
+        .into_string()
+        .unwrap();
+
+    file.write_all(config_str.as_bytes()).unwrap();
+
+    let h = Arc::new(ReloadableConfig::new(path.clone()).unwrap());
+    let original_config = h.get_config();
+
+    let pair = Arc::new((Mutex::new(false), Condvar::new()));
+    let pair2 = pair.clone();
+    let h_cloned = h.clone();
+    tokio::spawn(async move {
+        {
+            let &(ref lock, ref cvar) = &*pair;
+            let mut started = lock.lock().unwrap();
+            while !*started {
+                started = cvar.wait(started).unwrap();
+            }
+            drop(started);
+        };
+
+        let config_str = config_str_diff_addr();
+
+        let mut file = file.reopen().unwrap();
+        file.write_all(config_str.as_bytes()).unwrap();
+
+        h_cloned.reload(path).await.unwrap();
+    });
+
+    {
+        let &(ref lock, ref cvar) = &*pair2;
+        let mut started = lock.lock().unwrap();
+        *started = true;
+        cvar.notify_one();
+    }
+
+    let mut rx = h.new_subscriber();
+    rx.recv().await.unwrap();
+
+    let updated_config = h.get_config();
+    assert_ne!(
+        updated_config.server.json_rpc_address,
+        original_config.server.json_rpc_address
+    );
+}
+
+#[test]
+fn check_server_config() {
+    let config = read_config().server;
+    assert_eq!(
+        config.json_rpc_address,
+        SocketAddr::from_str(SERVER_JSON_RPC_ADDR).unwrap(),
+        "invalid server rpc address"
+    );
+}
+
+#[test]
+fn check_subnets_config() {
+    let config = read_config().subnets;
+
+    let root = &config["root"];
+    assert_eq!(root.id, *ROOTNET_ID);
+    assert_eq!(
+        root.jsonrpc_api_http,
+        Url::from_str(JSONRPC_API_HTTP).unwrap()
+    );
+    assert_eq!(
+        root.jsonrpc_api_ws.as_ref().unwrap(),
+        &Url::from_str(JSONRPC_API_WS).unwrap()
+    );
+    assert_eq!(root.auth_token.as_ref().unwrap(), ROOT_AUTH_TOKEN);
+
+    let child = &config["child"];
+    assert_eq!(child.id, SubnetID::from_str(CHILD_ID).unwrap(),);
+    assert_eq!(
+        child.jsonrpc_api_http,
+        Url::from_str(JSONRPC_API_HTTP).unwrap(),
+    );
+    assert_eq!(child.auth_token.as_ref().unwrap(), CHILD_AUTH_TOKEN,);
+    assert_eq!(
+        child.accounts.as_ref(),
+        vec![Address::from_str(ACCOUNT_ADDRESS).unwrap()],
+    );
+}
+
+fn config_str() -> String {
+    formatdoc!(
+        r#"
+            [server]
+            json_rpc_address = "{SERVER_JSON_RPC_ADDR}"
+            [subnets]
+            [subnets.root]
+            id = "{ROOT_ID}"
+            jsonrpc_api_http = "{JSONRPC_API_HTTP}"
+            jsonrpc_api_ws = "{JSONRPC_API_WS}"
+            auth_token = "{ROOT_AUTH_TOKEN}"
+            [subnets.child]
+            id = "{CHILD_ID}"
+            jsonrpc_api_http = "{JSONRPC_API_HTTP}"
+            auth_token = "{CHILD_AUTH_TOKEN}"
+            accounts = ["{ACCOUNT_ADDRESS}"]
+        "#
+    )
+}
+
+fn config_str_diff_addr() -> String {
+    formatdoc!(
+        r#"
+            [server]
+            json_rpc_address = "127.0.0.1:3031"
+            [subnets]
+            [subnets.root]
+            id = "{ROOT_ID}"
+            jsonrpc_api_http = "{JSONRPC_API_HTTP}"
+            jsonrpc_api_ws = "{JSONRPC_API_WS}"
+            auth_token = "{ROOT_AUTH_TOKEN}"
+            [subnets.child]
+            id = "{CHILD_ID}"
+            jsonrpc_api_http = "{JSONRPC_API_HTTP}"
+            auth_token = "{CHILD_AUTH_TOKEN}"
+            accounts = ["{ACCOUNT_ADDRESS}"]
+        "#
+    )
+}
+
+fn read_config() -> Config {
+    let config_str = formatdoc!(
+        r#"
+            [server]
+            json_rpc_address = "{SERVER_JSON_RPC_ADDR}"
+
+            [subnets]
+
+            [subnets.root]
+            id = "{ROOT_ID}"
+            jsonrpc_api_http = "{JSONRPC_API_HTTP}"
+            jsonrpc_api_ws = "{JSONRPC_API_WS}"
+            auth_token = "{ROOT_AUTH_TOKEN}"
+
+            [subnets.child]
+            id = "{CHILD_ID}"
+            jsonrpc_api_http = "{JSONRPC_API_HTTP}"
+            auth_token = "{CHILD_AUTH_TOKEN}"
+            accounts = ["{ACCOUNT_ADDRESS}"]
+        "#
+    );
+
+    Config::from_toml_str(config_str.as_str()).unwrap()
+}

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
 use std::io::Write;
 use std::net::SocketAddr;
 use std::str::FromStr;

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -43,9 +43,8 @@ async fn reload_works() {
 
     // A simple barrier implementation for testing.
     // Refer to: https://web.mit.edu/rust-lang_v1.25/arch/amd64_ubuntu1404/share/doc/rust/html/std/sync/struct.Condvar.html#examples
-    // Idea is after the main thread makes a new subscriber to make sure will receive broadcasted updates,
-    // then tokio spawned update config thread shall trigger the update. This way, we dont miss the
-    // update and stuck the main thread.
+    // Only when the main thread has created a new subscriber then we trigger then update the config file.
+    // This way, we dont miss the update and stuck the main thread.
     let pair = Arc::new((Mutex::new(false), Condvar::new()));
     let pair2 = pair.clone();
     let h_cloned = h.clone();

--- a/src/server/handlers/config.rs
+++ b/src/server/handlers/config.rs
@@ -1,0 +1,44 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
+//! Triggers a config reloading
+
+use crate::config::ReloadableConfig;
+use crate::server::JsonRPCRequestHandler;
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::sync::Arc;
+
+#[derive(Debug, Deserialize)]
+pub struct ReloadConfigParams {
+    pub path: Option<String>,
+}
+
+/// The create subnet json rpc method handler.
+pub(crate) struct ReloadConfigHandler {
+    config: Arc<ReloadableConfig>,
+    default_config_path: String,
+}
+
+impl ReloadConfigHandler {
+    pub fn new(config: Arc<ReloadableConfig>, default_config_path: String) -> Self {
+        Self {
+            config,
+            default_config_path,
+        }
+    }
+}
+
+#[async_trait]
+impl JsonRPCRequestHandler for ReloadConfigHandler {
+    type Request = ReloadConfigParams;
+    type Response = ();
+
+    async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
+        log::info!("received request to reload config: {request:?}");
+
+        let path = request
+            .path
+            .unwrap_or_else(|| self.default_config_path.clone());
+        self.config.reload(path).await
+    }
+}

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -2,20 +2,25 @@
 // SPDX-License-Identifier: MIT
 //! The module contains the handlers implementation for the json rpc server.
 
+mod config;
 pub mod create;
 
+use crate::config::ReloadableConfig;
 use crate::server::create::CreateSubnetHandler;
+use crate::server::handlers::config::ReloadConfigHandler;
 use crate::server::JsonRPCRequestHandler;
 use anyhow::{anyhow, Result};
 pub use create::{CreateSubnetParams, CreateSubnetResponse};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 pub type Method = String;
 
 /// A util enum to avoid Box<dyn> mess in Handlers struct
 enum HandlerWrapper {
     CreateSubnet(CreateSubnetHandler),
+    ReloadConfig(ReloadConfigHandler),
 }
 
 /// The collection of all json rpc handlers
@@ -24,13 +29,29 @@ pub struct Handlers {
 }
 
 impl Handlers {
-    pub fn new() -> Self {
+    /// We test the handlers separately and individually instead of from the handlers.
+    /// Convenient method for json rpc to test routing.
+    #[cfg(test)]
+    pub fn empty_handlers() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+
+    pub fn new(config_path_string: String) -> Result<Self> {
         let mut handlers = HashMap::new();
 
         let create_subnet = HandlerWrapper::CreateSubnet(CreateSubnetHandler {});
         handlers.insert(String::from("create_subnet"), create_subnet);
 
-        Self { handlers }
+        let config = ReloadableConfig::new(config_path_string.clone())?;
+        let reload_config = HandlerWrapper::ReloadConfig(ReloadConfigHandler::new(
+            Arc::new(config),
+            config_path_string,
+        ));
+        handlers.insert(String::from("reload_config"), reload_config);
+
+        Ok(Self { handlers })
     }
 
     pub async fn handle(&self, method: Method, params: Value) -> Result<Value> {
@@ -40,15 +61,13 @@ impl Handlers {
                     let r = handler.handle(serde_json::from_value(params)?).await?;
                     Ok(serde_json::to_value(r)?)
                 }
+                HandlerWrapper::ReloadConfig(handler) => {
+                    handler.handle(serde_json::from_value(params)?).await?;
+                    Ok(serde_json::to_value(())?)
+                }
             }
         } else {
             Err(anyhow!("method not supported"))
         }
-    }
-}
-
-impl Default for Handlers {
-    fn default() -> Self {
-        Self::new()
     }
 }


### PR DESCRIPTION
Update config while the json rpc server is running.

`ReloadableConfig` exposes the latest config through `get_config` method. Use this you will always the latest config. At the same time, it also exposes `new_subscriber`. If caller needs to be notified when config has updated, just make a new subscription. Once received a notification, then just read the config again to obtain the latest config.

See `reload_works` test case for sample usage. 