### PR TITLE
IPC-68: Max peers per query

### DIFF
--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -35,6 +35,7 @@ libp2p = { version = "0.50", default-features = false, features = [
 libp2p-bitswap = "0.25"
 libipld = { workspace = true }
 log = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 quickcheck = { workspace = true, optional = true }
 
@@ -46,7 +47,6 @@ fvm_ipld_blockstore = { workspace = true, optional = true }
 [dev-dependencies]
 quickcheck = { workspace = true }
 quickcheck_macros = { workspace = true }
-rand = { workspace = true }
 env_logger = { workspace = true }
 fvm_shared = { workspace = true, features = ["arb"] }
 fvm_ipld_hamt = "0.6"

--- a/ipld/resolver/tests/smoke.rs
+++ b/ipld/resolver/tests/smoke.rs
@@ -170,6 +170,7 @@ fn make_config(rng: &mut StdRng, cluster_size: u32, bootstrap_addr: Option<Multi
             listen_addr: Multiaddr::from(Protocol::Memory(rng.gen::<u64>())),
             expected_peer_count: cluster_size,
             max_incoming: cluster_size,
+            max_peers_per_query: cluster_size,
         },
         network: NetworkConfig {
             local_key: Keypair::generate_secp256k1(),


### PR DESCRIPTION
Closes #68 

Changes the strategy for how many peers to contact in bitswap, from "first to all connected, then if failed then all other known providers" to "the first N of connected and known, then the next N, and so on". Also shuffles the peers so we don't always go to the same one.