### PR TITLE
IPC-70: Bootstrap Eclipse attack protection 

### DIFF
--- a/ipld/resolver/src/service.rs
+++ b/ipld/resolver/src/service.rs
@@ -282,7 +282,7 @@ impl<P: StoreParams> Service<P> {
         } else if let identify::Event::Received { peer_id, info } = event {
             debug!("protocols supported by {peer_id}: {:?}", info.protocols);
             debug!("adding identified address of {peer_id} to {}", self.peer_id);
-            self.discovery_mut().add_identified(&peer_id, &info);
+            self.discovery_mut().add_identified(&peer_id, info);
         }
     }
 


### PR DESCRIPTION
Closes #70 

Changes the `Discovery` behaviour to buffer `Identify::Info` records while the Kademlia bootstrapping is ongoing.