### PR TITLE
IPC-67: Gossip to new joiners

### DIFF
--- a/ipld/resolver/src/behaviour/membership.rs
+++ b/ipld/resolver/src/behaviour/membership.rs
@@ -286,6 +286,16 @@ impl Behaviour {
 
     /// Publish our provider record when we encounter a new peer, unless we have recently done so.
     fn publish_for_new_peer(&mut self, peer_id: PeerId) {
+        if self.subnet_ids.is_empty() {
+            // We have nothing, so there's no need for them to know this ASAP.
+            // The reason we shouldn't disable periodic publishing of empty
+            // records completely is because it would also remove one of
+            // triggers for non-connected peers to eagerly publish their
+            // subnets when they see our empty records. Plus they could
+            // be good to show on metrics, to have a single source of
+            // the cluster size available on any node.
+            return;
+        }
         let now = Timestamp::now();
         if self.last_publish_timestamp > now - self.min_time_between_publish {
             debug!("recently published, not publishing again for peer {peer_id}");

--- a/ipld/resolver/src/behaviour/membership.rs
+++ b/ipld/resolver/src/behaviour/membership.rs
@@ -9,7 +9,7 @@ use libp2p::core::connection::ConnectionId;
 use libp2p::gossipsub::error::SubscriptionError;
 use libp2p::gossipsub::{
     GossipsubConfigBuilder, GossipsubEvent, GossipsubMessage, IdentTopic, MessageAuthenticity,
-    MessageId, Topic,
+    MessageId, Topic, TopicHash,
 };
 use libp2p::identity::Keypair;
 use libp2p::swarm::derive_prelude::FromSwarm;
@@ -21,11 +21,11 @@ use libp2p::{
     PeerId,
 };
 use log::{debug, error, warn};
-use tokio::time::Interval;
+use tokio::time::{Instant, Interval};
 
 use crate::hash::blake2b_256;
 use crate::provider_cache::{ProviderDelta, SubnetProviderCache};
-use crate::provider_record::{SignedProviderRecord, Timestamp};
+use crate::provider_record::{ProviderRecord, SignedProviderRecord, Timestamp};
 
 use super::NetworkConfig;
 
@@ -56,6 +56,8 @@ pub struct Config {
     pub max_subnets: usize,
     /// Publish interval for supported subnets.
     pub publish_interval: Duration,
+    /// Minimum time between publishing own provider record in reaction to new joiners.
+    pub min_time_between_publish: Duration,
     /// Maximum age of provider records before the peer is removed without an update.
     pub max_provider_age: Duration,
 }
@@ -90,6 +92,12 @@ pub struct Behaviour {
     /// This acts like a heartbeat; if a peer doesn't publish its snapshot for a long time,
     /// other agents can prune it from their cache and not try to contact for resolution.
     publish_interval: Interval,
+    /// Minimum time between publishing own provider record in reaction to new joiners.
+    min_time_between_publish: Duration,
+    /// Last time we gossiped our own provider record.
+    last_publish_timestamp: Timestamp,
+    /// Next time we will gossip our own provider record.
+    next_publish_timestamp: Timestamp,
     /// Maximum time a provider can be without an update before it's pruned from the cache.
     max_provider_age: Duration,
 }
@@ -141,6 +149,9 @@ impl Behaviour {
             subnet_ids: Default::default(),
             provider_cache: SubnetProviderCache::new(mc.max_subnets, mc.static_subnets),
             publish_interval: interval,
+            min_time_between_publish: mc.min_time_between_publish,
+            last_publish_timestamp: Timestamp::default(),
+            next_publish_timestamp: Timestamp::now() + mc.publish_interval,
             max_provider_age: mc.max_provider_age,
         })
     }
@@ -188,6 +199,9 @@ impl Behaviour {
         let record = SignedProviderRecord::new(&self.local_key, self.subnet_ids.clone())?;
         let data = record.into_envelope().into_protobuf_encoding();
         let _msg_id = self.inner.publish(self.membership_topic.clone(), data)?;
+        self.last_publish_timestamp = Timestamp::now();
+        self.next_publish_timestamp = self.last_publish_timestamp + self.publish_interval.period();
+        self.publish_interval.reset(); // In case the change wasn't tiggered by the schedule.
         Ok(())
     }
 
@@ -195,7 +209,8 @@ impl Behaviour {
     ///
     /// Call this method when the discovery service learns the address of a peer.
     pub fn set_routable(&mut self, peer_id: PeerId) {
-        self.provider_cache.set_routable(peer_id)
+        self.provider_cache.set_routable(peer_id);
+        self.publish_to_new_peer(peer_id);
     }
 
     /// Mark a peer as unroutable in the cache.
@@ -217,14 +232,10 @@ impl Behaviour {
     /// then raise domain event to let the rest of the application know about a
     /// provider. Also update all the book keeping in the behaviour that we use
     /// to answer future queries about the topic.
-    fn handle_message(&mut self, msg: GossipsubMessage) -> Option<Event> {
+    fn handle_message(&mut self, msg: GossipsubMessage) {
         if msg.topic == self.membership_topic.hash() {
             match SignedProviderRecord::from_bytes(&msg.data).map(|r| r.into_record()) {
-                Ok(record) => match self.provider_cache.add_provider(&record) {
-                    None => return Some(Event::Skipped(record.peer_id)),
-                    Some(d) if d.is_empty() => return None,
-                    Some(d) => return Some(Event::Updated(record.peer_id, d)),
-                },
+                Ok(record) => self.handle_provider_record(record),
                 Err(e) => {
                     warn!(
                         "Gossip message from peer {:?} could not be deserialized: {e}",
@@ -233,9 +244,54 @@ impl Behaviour {
                 }
             }
         } else {
-            warn!("unknown gossipsub topic: {}", msg.topic);
+            warn!(
+                "unknown gossipsub topic in message from {:?}: {}",
+                msg.source, msg.topic
+            );
         }
-        None
+    }
+
+    /// Try to add a provider record to the cache.
+    fn handle_provider_record(&mut self, record: ProviderRecord) {
+        let event = match self.provider_cache.add_provider(&record) {
+            None => Some(Event::Skipped(record.peer_id)),
+            Some(d) if d.is_empty() => None,
+            Some(d) => Some(Event::Updated(record.peer_id, d)),
+        };
+
+        if let Some(event) = event {
+            self.outbox.push_back(event);
+        }
+    }
+
+    /// Handle new subscribers to the membership topic.
+    fn handle_subscriber(&mut self, peer_id: PeerId, topic: TopicHash) {
+        if topic == self.membership_topic.hash() {
+            self.publish_to_new_peer(peer_id)
+        } else {
+            warn!(
+                "unknown gossipsub topic in subscription from {}: {}",
+                peer_id, topic
+            )
+        }
+    }
+
+    /// Publish our provider record when we encounter a new peer, unless we have recently done so.
+    fn publish_to_new_peer(&mut self, peer_id: PeerId) {
+        let now = Timestamp::now();
+        if self.last_publish_timestamp > now - self.min_time_between_publish {
+            debug!("recently published, not publishing again for peer {peer_id}");
+        } else if self.next_publish_timestamp <= now + self.min_time_between_publish {
+            debug!("publishing soon for new peer {peer_id}"); // don't let new joiners delay it forever by hitting the next block
+        } else {
+            debug!("publishing for new peer {peer_id}");
+            // Create a new timer, rather than publish and reset. This way we don't repeat error handling.
+            // Give some time for Kademlia and Identify to do their bit on both sides. Works better in tests.
+            let delayed = Instant::now() + self.min_time_between_publish;
+            self.next_publish_timestamp = now + self.min_time_between_publish;
+            self.publish_interval =
+                tokio::time::interval_at(delayed, self.publish_interval.period())
+        }
     }
 
     /// Remove any membership record that hasn't been updated for a long time.
@@ -306,16 +362,17 @@ impl NetworkBehaviour for Behaviour {
                         // insignificant. For this reason I oped to use messages instead, and let the content
                         // carry the information, spreading through the Gossipsub network regardless of the
                         // number of connected peers.
-                        GossipsubEvent::Subscribed { .. } | GossipsubEvent::Unsubscribed { .. } => {
+                        GossipsubEvent::Subscribed { peer_id, topic } => {
+                            self.handle_subscriber(peer_id, topic)
                         }
+
+                        GossipsubEvent::Unsubscribed { .. } => {}
                         // Log potential misconfiguration.
                         GossipsubEvent::GossipsubNotSupported { peer_id } => {
                             debug!("peer {peer_id} doesn't support gossipsub");
                         }
                         GossipsubEvent::Message { message, .. } => {
-                            if let Some(ev) = self.handle_message(message) {
-                                return Poll::Ready(NetworkBehaviourAction::GenerateEvent(ev));
-                            }
+                            self.handle_message(message);
                         }
                     }
                 }

--- a/ipld/resolver/src/provider_cache.rs
+++ b/ipld/resolver/src/provider_cache.rs
@@ -83,6 +83,11 @@ impl SubnetProviderCache {
         self.routable_peers.contains(peer_id)
     }
 
+    /// Check whether we have received recent updates from a peer.
+    pub fn has_timestamp(&self, peer_id: &PeerId) -> bool {
+        self.peer_timestamps.contains_key(peer_id)
+    }
+
     /// Try to add a provider to the cache.
     ///
     /// Returns `None` if the peer is not routable and nothing could be added.

--- a/ipld/resolver/src/provider_cache.rs
+++ b/ipld/resolver/src/provider_cache.rs
@@ -20,6 +20,7 @@ impl ProviderDelta {
     }
 }
 
+/// Track which subnets are provided for by which set of peers.
 pub struct SubnetProviderCache {
     /// Maximum number of subnets to track, to protect against DoS attacks, trying to
     /// flood someone with subnets that don't actually exist. When the number of subnets
@@ -78,8 +79,8 @@ impl SubnetProviderCache {
     }
 
     /// Check if a peer has been marked as routable.
-    pub fn is_routable(&self, peer_id: PeerId) -> bool {
-        self.routable_peers.contains(&peer_id)
+    pub fn is_routable(&self, peer_id: &PeerId) -> bool {
+        self.routable_peers.contains(peer_id)
     }
 
     /// Try to add a provider to the cache.
@@ -89,7 +90,7 @@ impl SubnetProviderCache {
     /// Returns `Some` if the peer is routable, containing the newly added
     /// and newly removed associations for this peer.
     pub fn add_provider(&mut self, record: &ProviderRecord) -> Option<ProviderDelta> {
-        if !self.is_routable(record.peer_id) {
+        if !self.is_routable(&record.peer_id) {
             return None;
         }
 

--- a/ipld/resolver/tests/smoke.rs
+++ b/ipld/resolver/tests/smoke.rs
@@ -183,7 +183,8 @@ fn make_config(rng: &mut StdRng, cluster_size: u32, bootstrap_addr: Option<Multi
         membership: MembershipConfig {
             static_subnets: vec![],
             max_subnets: 10,
-            publish_interval: Duration::from_secs(1),
+            publish_interval: Duration::from_secs(5),
+            min_time_between_publish: Duration::from_secs(1),
             max_provider_age: Duration::from_secs(60),
         },
     };


### PR DESCRIPTION
Closes #67 

So far we published provider records whenever they changed, and independently at regular intervals. This presented a trade-off in that new joiners would have to wait until they get a full picture of subnet providers. In the #64 I had to set the publish interval low, because currently records are only accepted once the listening address of the other party is known, and it takes time for `Identify` and `Kademlia` to work. 

The PR changes this so that records are also published at the following triggers:
* A peer subscribes to the membership topic - this indicates we just established a Gossipsub connection with them and they might be interested to know about our subnets
* A peer became routable - this indicates that we just received their address through Identify or Kademlia; it's possible that they already subscribed in Gossipsub, but we did not know their listening address at the time
* We received the first provider record from a peer - unlike the first point and Identify, this doesn't need for us to be connected to them; but they are new (to us) and they might be interested in what we provide

To protect against rapid republishing, there's a new `min_time_between_publish` setting and we will not publish if:
* the last publish time was no longer than `min_time_between_publish` ago
* the next publish time is no longer than `min_time_between_publish` in the future
. 
The second condition is for a technical reason: in the smoke test if I published immediately, the test failed, so when we get the subscription, we did not have Identify yet; therefore I delayed the publishing by `min_time_betwen_publish`. But then I want to protect against peers constantly triggering this behaviour and pushing out publishing indefinitely.

The `min_time_between_publish` setting should be set around the network propagation time.