### PR TITLE
Disable 3 flaky tests

### DIFF
--- a/src/jsonrpc/tests.rs
+++ b/src/jsonrpc/tests.rs
@@ -35,6 +35,7 @@ async fn test_request_error() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn test_request_with_params() {
     let url = Url::parse(HTTP_ENDPOINT).unwrap();
     let client = JsonRpcClientImpl::new(url, None);

--- a/src/lotus/tests.rs
+++ b/src/lotus/tests.rs
@@ -15,6 +15,7 @@ fn get_lotus_client() -> LotusJsonRPCClient<JsonRpcClientImpl> {
 }
 
 #[tokio::test]
+#[ignore]
 async fn state_network_name() {
     let client = get_lotus_client();
     assert_eq!(client.state_network_name().await.unwrap(), "mainnet");
@@ -31,6 +32,7 @@ async fn state_network_version() {
 }
 
 #[tokio::test]
+#[ignore]
 async fn state_actor_manifest_cid() {
     let client = get_lotus_client();
 


### PR DESCRIPTION
Disable 3 flaky tests:
- test_request_with_params
- state_network_name
- state_actor_manifest_cid

These 3 tests are just querying the public lotus node to check the lotus response format.  They worked fine previously, but recently, they return `Method not supported` error unpredictably. 

The point for these tests are just checking the response format, which we have already confirmed. Disable the run for now as they are breaking the CICD.