### PR TITLE
IPC-65: Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf6690c370453db30743b373a60ba498fc0d6d83b11f4abfd87a84a075db5dd4"
+checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
 dependencies = [
  "asn1-rs-derive 0.4.0",
  "asn1-rs-impl",
@@ -305,19 +305,18 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
+checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
 dependencies = [
  "event-listener",
- "futures-lite",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.64"
+version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd7fce9ba8c3c042128ce72d8b2ddbf3a05747efb67ea0313c635e10bda47a2"
+checksum = "b84f9ebcc6c1f5b8cb160f6990096a5c127f423fcb6e1ccc46c370cbdfb75dfc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -680,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.6"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b0588d44d4d63a87dbd75c136c166bbfd9a86a31cb89e09906521c7d3f5e3"
+checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
  "clap_derive",
@@ -695,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.1.0"
+version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "684a277d672e91966334af371f1a7b5833f9aa00b07c84e92fbce95e00208ce8"
+checksum = "44bec8e5c9d09e439c4335b1af0abaab56dcf3b94999a936e1bb47b9134288f0"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -894,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -904,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -915,22 +914,22 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset 0.8.0",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
@@ -1126,11 +1125,11 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.1.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d4bc9b0db0a0df9ae64634ac5bdefb7afcb534e182275ca0beadbe486701c1"
+checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
 dependencies = [
- "asn1-rs 0.5.1",
+ "asn1-rs 0.5.2",
  "displaydoc",
  "nom",
  "num-bigint",
@@ -1265,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "dtoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00704156a7de8df8da0911424e30c2049957b0a714542a44e05fe693dd85313"
+checksum = "65d09067bfacaa79114679b279d7f5885b53295b1e2cfb4e79c8e4bd3d633169"
 
 [[package]]
 name = "ecdsa"
@@ -1430,9 +1429,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a214f5bb88731d436478f3ae1f8a277b62124089ba9fb67f4f93fb100ef73c90"
+checksum = "54b2f3c51e4dd999930845da5d10a48775b8fe4ca9f4f9ec1f9161f334da5dfe"
 
 [[package]]
 name = "fil_actors_runtime"
@@ -1965,9 +1964,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
 dependencies = [
  "bytes",
  "fnv",
@@ -2270,9 +2269,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2b9d82064e8a0226fddb3547f37f28eaa46d0fc210e275d835f08cf3b76a7"
+checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
 
 [[package]]
 name = "inout"
@@ -2325,9 +2324,9 @@ checksum = "ec58677acfea8a15352d42fc87d11d63596ade9239e0a7c9352914417515dbe6"
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+checksum = "cfa919a82ea574332e2de6e74b4c36e74d41982b335080fa59d4ef31be20fdf3"
 dependencies = [
  "libc",
  "windows-sys 0.45.0",
@@ -2336,7 +2335,7 @@ dependencies = [
 [[package]]
 name = "ipc-gateway"
 version = "0.0.1"
-source = "git+https://github.com/consensus-shipyard/ipc-actors.git#436613a70e85efe48b722941306ce424297754ee"
+source = "git+https://github.com/consensus-shipyard/ipc-actors.git#1e1ea9e1ddca1404460f04bcbcad2bd83f3d83e5"
 dependencies = [
  "anyhow",
  "cid",
@@ -2365,7 +2364,7 @@ dependencies = [
 [[package]]
 name = "ipc-sdk"
 version = "0.0.1"
-source = "git+https://github.com/consensus-shipyard/ipc-actors.git#436613a70e85efe48b722941306ce424297754ee"
+source = "git+https://github.com/consensus-shipyard/ipc-actors.git#1e1ea9e1ddca1404460f04bcbcad2bd83f3d83e5"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.3.3",
@@ -2379,7 +2378,7 @@ dependencies = [
 [[package]]
 name = "ipc-subnet-actor"
 version = "0.0.1"
-source = "git+https://github.com/consensus-shipyard/ipc-actors.git#436613a70e85efe48b722941306ce424297754ee"
+source = "git+https://github.com/consensus-shipyard/ipc-actors.git#1e1ea9e1ddca1404460f04bcbcad2bd83f3d83e5"
 dependencies = [
  "anyhow",
  "cid",
@@ -2458,10 +2457,12 @@ dependencies = [
  "fvm_ipld_hamt 0.6.1",
  "fvm_shared 3.0.0-alpha.17",
  "ipc-sdk",
+ "lazy_static",
  "libipld",
  "libp2p",
  "libp2p-bitswap",
  "log",
+ "prometheus",
  "quickcheck",
  "quickcheck_macros",
  "rand 0.8.5",
@@ -2495,8 +2496,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
- "io-lifetimes 1.0.5",
- "rustix 0.36.8",
+ "io-lifetimes 1.0.6",
+ "rustix 0.36.9",
  "windows-sys 0.45.0",
 ]
 
@@ -2511,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "ittapi-rs"
@@ -2526,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "jobserver"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "068b1ee6743e4d11fb9c6a1e6064b3693a1b600e7f5f5988047d98b3dc9fb90b"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
 dependencies = [
  "libc",
 ]
@@ -2645,9 +2646,9 @@ checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
 
 [[package]]
 name = "libp2p"
-version = "0.50.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e0a0d2f693675f49ded13c5d510c48b78069e23cbd9108d7ccd59f6dc568819"
+checksum = "9c7b0104790be871edcf97db9bd2356604984e623a08d825c3f27852290266b8"
 dependencies = [
  "bytes",
  "futures",
@@ -2662,7 +2663,7 @@ dependencies = [
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-mplex",
- "libp2p-noise 0.41.0",
+ "libp2p-noise",
  "libp2p-ping",
  "libp2p-plaintext",
  "libp2p-quic",
@@ -2937,29 +2938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libp2p-noise"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1216f9ec823ac7a2289b954674c54cbce81c9e45920b4fcf173018ede4295246"
-dependencies = [
- "bytes",
- "curve25519-dalek 3.2.0",
- "futures",
- "libp2p-core 0.39.0",
- "log",
- "once_cell",
- "prost",
- "prost-build",
- "rand 0.8.5",
- "sha2 0.10.6",
- "snow",
- "static_assertions",
- "thiserror",
- "x25519-dalek 1.1.1",
- "zeroize",
-]
-
-[[package]]
 name = "libp2p-ping"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2994,15 +2972,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.7.0-alpha.2"
+version = "0.7.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971f629ff7519f4d4889a7c981f0dc09c6ad493423cd8a13ee442de241bc8c8"
+checksum = "01e7c867e95c8130667b24409d236d37598270e6da69b3baf54213ba31ffca59"
 dependencies = [
  "bytes",
  "futures",
  "futures-timer",
  "if-watch",
- "libp2p-core 0.39.0",
+ "libp2p-core 0.38.0",
  "libp2p-tls",
  "log",
  "parking_lot 0.12.1",
@@ -3100,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-webrtc"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4401ec550d36f413310ba5d4bf564bb21f89fb1601cadb32b2300f8bc1eb5b"
+checksum = "cdb6cd86dd68cba72308ea05de1cebf3ba0ae6e187c40548167955d4e3970f6a"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -3111,10 +3089,10 @@ dependencies = [
  "futures-timer",
  "hex",
  "if-watch",
- "libp2p-core 0.39.0",
- "libp2p-noise 0.42.0",
+ "libp2p-core 0.38.0",
+ "libp2p-noise",
  "log",
- "multihash 0.17.0",
+ "multihash 0.16.3",
  "prost",
  "prost-build",
  "prost-codec",
@@ -3302,9 +3280,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -3561,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e21fbb6f3d253a14df90eb0000a6066780a15dd901a7519ce02d77a94985b"
+checksum = "6471bf08e7ac0135876a9581bf3217ef0333c191c128d34878079f42ee150411"
 dependencies = [
  "bytes",
  "futures",
@@ -3733,7 +3711,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
 dependencies = [
- "asn1-rs 0.5.1",
+ "asn1-rs 0.5.2",
 ]
 
 [[package]]
@@ -3887,9 +3865,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
 
 [[package]]
 name = "pem"
@@ -3917,9 +3895,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.5"
+version = "2.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "028accff104c4e513bad663bbcd2ad7cfd5304144404c31ed0a77ac103d00660"
+checksum = "8cbd939b234e95d72bc393d51788aec68aeeb5d51e748ca08ff3aad58cb722f7"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -4046,9 +4024,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
+checksum = "4ebcd279d20a4a0a2404a33056388e950504d891c855c7975b9a8fef75f3bf04"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -4366,9 +4344,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -4376,9 +4354,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.2"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -4639,13 +4617,13 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.8"
+version = "0.36.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes 1.0.5",
+ "io-lifetimes 1.0.6",
  "libc",
  "linux-raw-sys 0.1.4",
  "windows-sys 0.45.0",
@@ -4687,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5583e89e108996506031660fe09baa5011b9dd0341b89029313006d1fb508d70"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "rw-stream-sink"
@@ -4704,9 +4682,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "safemem"
@@ -4855,9 +4833,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "3a382c72b4ba118526e187430bb4963cd6d55051ebf13d9b25574d379cc98d20"
 dependencies = [
  "serde_derive",
 ]
@@ -4882,9 +4860,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "1ef476a5790f0f6decbc66726b6e5d63680ed518283e64c7df415989d880954f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4905,9 +4883,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -4916,9 +4894,9 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5ec9fa74a20ebbe5d9ac23dac1fc96ba0ecfe9f50f2843b52e537b10fbcb4e"
+checksum = "395627de918015623b32e7669714206363a7fc00382bf477e72c1f7533e8eafc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5089,9 +5067,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -5246,7 +5224,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix 0.36.8",
+ "rustix 0.36.9",
  "windows-sys 0.42.0",
 ]
 
@@ -5281,18 +5259,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
+checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.38"
+version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
+checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5353,9 +5331,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5368,7 +5346,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -5686,9 +5664,9 @@ checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-normalization"
@@ -5957,9 +5935,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f7d56227d910901ce12dfd19acc40c12687994dfb3f57c90690f80be946ec5"
+checksum = "4eff853c4f09eec94d76af527eddad4e9de13b11d6286a1ef7134bc30135a2b7"
 dependencies = [
  "leb128",
 ]
@@ -6171,9 +6149,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "54.0.1"
+version = "55.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d48d9d731d835f4f8dacbb8de7d47be068812cb9877f5c60d408858778d8d2a"
+checksum = "4984d3e1406571f4930ba5cf79bd70f75f41d0e87e17506e0bd19b0e5d085f05"
 dependencies = [
  "leb128",
  "memchr",
@@ -6183,9 +6161,9 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1db2e3ed05ea31243761439194bec3af6efbbaf87c4c8667fb879e4f23791a0"
+checksum = "af2b53f4da14db05d32e70e9c617abdf6620c575bd5dd972b7400037b4df2091"
 dependencies = [
  "wast",
 ]
@@ -6290,7 +6268,7 @@ dependencies = [
  "byteorder",
  "ccm",
  "curve25519-dalek 3.2.0",
- "der-parser 8.1.0",
+ "der-parser 8.2.0",
  "elliptic-curve",
  "hkdf",
  "hmac 0.12.1",
@@ -6615,9 +6593,9 @@ checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winnow"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658"
+checksum = "ee7b2c67f962bf5042bfd8b6a916178df33a26eec343ae064cb8e069f638fa6f"
 dependencies = [
  "memchr",
 ]
@@ -6678,10 +6656,10 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
 dependencies = [
- "asn1-rs 0.5.1",
+ "asn1-rs 0.5.2",
  "base64 0.13.1",
  "data-encoding",
- "der-parser 8.1.0",
+ "der-parser 8.2.0",
  "lazy_static",
  "nom",
  "oid-registry 0.6.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,10 @@ tempfile = "3.4.0"
 
 [workspace.dependencies]
 anyhow = "1.0"
+lazy_static = "1.4"
 log = "0.4"
 env_logger = "0.10"
+prometheus = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1.16", features = ["full"] }

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -14,6 +14,7 @@ blake2b_simd = { workspace = true }
 bloom = "0.3"
 thiserror = { workspace = true }
 tokio = { workspace = true }
+lazy_static = { workspace = true }
 libp2p = { version = "0.50", default-features = false, features = [
   "gossipsub",
   "kad",
@@ -35,6 +36,7 @@ libp2p = { version = "0.50", default-features = false, features = [
 libp2p-bitswap = "0.25"
 libipld = { workspace = true }
 log = { workspace = true }
+prometheus = { workspace = true }
 rand = { workspace = true }
 serde = { workspace = true }
 quickcheck = { workspace = true, optional = true }

--- a/ipld/resolver/src/lib.rs
+++ b/ipld/resolver/src/lib.rs
@@ -5,6 +5,7 @@ mod hash;
 mod provider_cache;
 mod provider_record;
 mod service;
+mod stats;
 
 #[cfg(any(test, feature = "arb"))]
 mod arb;

--- a/ipld/resolver/src/provider_cache.rs
+++ b/ipld/resolver/src/provider_cache.rs
@@ -8,8 +8,9 @@ use libp2p::PeerId;
 use crate::provider_record::{ProviderRecord, Timestamp};
 
 /// Change in the supported subnets of a peer.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ProviderDelta {
+    pub is_new: bool,
     pub added: Vec<SubnetID>,
     pub removed: Vec<SubnetID>,
 }
@@ -78,6 +79,11 @@ impl SubnetProviderCache {
         }
     }
 
+    /// Number of routable peers.
+    pub fn num_routable(&mut self) -> usize {
+        self.routable_peers.len()
+    }
+
     /// Check if a peer has been marked as routable.
     pub fn is_routable(&self, peer_id: &PeerId) -> bool {
         self.routable_peers.contains(peer_id)
@@ -99,7 +105,11 @@ impl SubnetProviderCache {
             return None;
         }
 
-        let mut delta = ProviderDelta::default();
+        let mut delta = ProviderDelta {
+            is_new: !self.has_timestamp(&record.peer_id),
+            added: Vec::new(),
+            removed: Vec::new(),
+        };
 
         let timestamp = self.peer_timestamps.entry(record.peer_id).or_default();
 

--- a/ipld/resolver/src/stats.rs
+++ b/ipld/resolver/src/stats.rs
@@ -1,0 +1,107 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
+use lazy_static::lazy_static;
+use prometheus::{Histogram, HistogramOpts, IntCounter, IntGauge, Registry};
+
+lazy_static! {
+    pub static ref PING_RTT: Histogram =
+        Histogram::with_opts(HistogramOpts::new("ping_rtt", "Ping roundtrip time")).unwrap();
+    pub static ref PING_TIMEOUT: IntCounter =
+        IntCounter::new("ping_timeouts", "Number of timed out pings").unwrap();
+    pub static ref PING_FAILURE: IntCounter =
+        IntCounter::new("ping_failure", "Number of failed pings").unwrap();
+    pub static ref PING_SUCCESS: IntCounter =
+        IntCounter::new("ping_success", "Number of successful pings",).unwrap();
+    pub static ref IDENTIFY_FAILURE: IntCounter =
+        IntCounter::new("identify_failure", "Number of Identify errors",).unwrap();
+    pub static ref IDENTIFY_RECEIVED: IntCounter =
+        IntCounter::new("identify_received", "Number of Identify infos received",).unwrap();
+    pub static ref DISCOVERY_BACKGROUND_LOOKUP: IntCounter = IntCounter::new(
+        "discovery_background_lookup",
+        "Number of background lookups started",
+    )
+    .unwrap();
+    pub static ref DISCOVERY_CONNECTED_PEERS: IntGauge =
+        IntGauge::new("discovery_connected_peers", "Number of connections",).unwrap();
+    pub static ref MEMBERSHIP_SKIPPED_PEERS: IntCounter =
+        IntCounter::new("membership_skipped_peers", "Number of providers skipped",).unwrap();
+    pub static ref MEMBERSHIP_ROUTABLE_PEERS: IntGauge =
+        IntGauge::new("membership_routable_peers", "Number of routable peers").unwrap();
+    pub static ref MEMBERSHIP_PROVIDER_PEERS: IntGauge =
+        IntGauge::new("membership_provider_peers", "Number of unique providers").unwrap();
+    pub static ref MEMBERSHIP_UNKNOWN_TOPIC: IntCounter = IntCounter::new(
+        "membership_unknown_topic",
+        "Number of messages with unknown topic"
+    )
+    .unwrap();
+    pub static ref MEMBERSHIP_INVALID_MESSAGE: IntCounter = IntCounter::new(
+        "membership_invalid_message",
+        "Number of invalid messages received"
+    )
+    .unwrap();
+    pub static ref MEMBERSHIP_PUBLISH_SUCCESS: IntCounter =
+        IntCounter::new("membership_publish_total", "Number of published messages").unwrap();
+    pub static ref MEMBERSHIP_PUBLISH_FAILURE: IntCounter = IntCounter::new(
+        "membership_publish_failure",
+        "Number of failed publish attempts"
+    )
+    .unwrap();
+    pub static ref CONTENT_RESOLVE_RUNNING: IntGauge = IntGauge::new(
+        "content_resolve_running",
+        "Number of currently running content resolutions"
+    )
+    .unwrap();
+    pub static ref CONTENT_RESOLVE_NO_PEERS: IntCounter = IntCounter::new(
+        "content_resolve_no_peers",
+        "Number of resolutions with no known peers"
+    )
+    .unwrap();
+    pub static ref CONTENT_RESOLVE_SUCCESS: IntCounter = IntCounter::new(
+        "content_resolve_success",
+        "Number of successful resolutions"
+    )
+    .unwrap();
+    pub static ref CONTENT_RESOLVE_FAILURE: IntCounter =
+        IntCounter::new("content_resolve_success", "Number of failed resolutions").unwrap();
+    pub static ref CONTENT_RESOLVE_FALLBACK: IntCounter = IntCounter::new(
+        "content_resolve_fallback",
+        "Number of resolutions that fall back on secondary peers"
+    )
+    .unwrap();
+    pub static ref CONTENT_RESOLVE_PEERS: Histogram = Histogram::with_opts(HistogramOpts::new(
+        "content_resolve_peers",
+        "Number of peers found for resolution from a subnet"
+    ))
+    .unwrap();
+    pub static ref CONTENT_CONNECTED_PEERS: Histogram = Histogram::with_opts(HistogramOpts::new(
+        "content_connected_peers",
+        "Number of connected peers in a resolution"
+    ))
+    .unwrap();
+}
+
+pub fn register_metrics(registry: &Registry) -> anyhow::Result<()> {
+    registry.register(Box::new(PING_RTT.clone()))?;
+    registry.register(Box::new(PING_TIMEOUT.clone()))?;
+    registry.register(Box::new(PING_FAILURE.clone()))?;
+    registry.register(Box::new(PING_SUCCESS.clone()))?;
+    registry.register(Box::new(IDENTIFY_FAILURE.clone()))?;
+    registry.register(Box::new(IDENTIFY_RECEIVED.clone()))?;
+    registry.register(Box::new(DISCOVERY_BACKGROUND_LOOKUP.clone()))?;
+    registry.register(Box::new(DISCOVERY_CONNECTED_PEERS.clone()))?;
+    registry.register(Box::new(MEMBERSHIP_SKIPPED_PEERS.clone()))?;
+    registry.register(Box::new(MEMBERSHIP_ROUTABLE_PEERS.clone()))?;
+    registry.register(Box::new(MEMBERSHIP_PROVIDER_PEERS.clone()))?;
+    registry.register(Box::new(MEMBERSHIP_UNKNOWN_TOPIC.clone()))?;
+    registry.register(Box::new(MEMBERSHIP_INVALID_MESSAGE.clone()))?;
+    registry.register(Box::new(MEMBERSHIP_PUBLISH_SUCCESS.clone()))?;
+    registry.register(Box::new(MEMBERSHIP_PUBLISH_FAILURE.clone()))?;
+    registry.register(Box::new(CONTENT_RESOLVE_RUNNING.clone()))?;
+    registry.register(Box::new(CONTENT_RESOLVE_NO_PEERS.clone()))?;
+    registry.register(Box::new(CONTENT_RESOLVE_SUCCESS.clone()))?;
+    registry.register(Box::new(CONTENT_RESOLVE_FAILURE.clone()))?;
+    registry.register(Box::new(CONTENT_RESOLVE_FALLBACK.clone()))?;
+    registry.register(Box::new(CONTENT_RESOLVE_PEERS.clone()))?;
+    registry.register(Box::new(CONTENT_CONNECTED_PEERS.clone()))?;
+    Ok(())
+}

--- a/ipld/resolver/src/stats.rs
+++ b/ipld/resolver/src/stats.rs
@@ -3,105 +3,108 @@
 use lazy_static::lazy_static;
 use prometheus::{Histogram, HistogramOpts, IntCounter, IntGauge, Registry};
 
-lazy_static! {
-    pub static ref PING_RTT: Histogram =
-        Histogram::with_opts(HistogramOpts::new("ping_rtt", "Ping roundtrip time")).unwrap();
-    pub static ref PING_TIMEOUT: IntCounter =
-        IntCounter::new("ping_timeouts", "Number of timed out pings").unwrap();
-    pub static ref PING_FAILURE: IntCounter =
-        IntCounter::new("ping_failure", "Number of failed pings").unwrap();
-    pub static ref PING_SUCCESS: IntCounter =
-        IntCounter::new("ping_success", "Number of successful pings",).unwrap();
-    pub static ref IDENTIFY_FAILURE: IntCounter =
-        IntCounter::new("identify_failure", "Number of Identify errors",).unwrap();
-    pub static ref IDENTIFY_RECEIVED: IntCounter =
-        IntCounter::new("identify_received", "Number of Identify infos received",).unwrap();
-    pub static ref DISCOVERY_BACKGROUND_LOOKUP: IntCounter = IntCounter::new(
-        "discovery_background_lookup",
-        "Number of background lookups started",
-    )
-    .unwrap();
-    pub static ref DISCOVERY_CONNECTED_PEERS: IntGauge =
-        IntGauge::new("discovery_connected_peers", "Number of connections",).unwrap();
-    pub static ref MEMBERSHIP_SKIPPED_PEERS: IntCounter =
-        IntCounter::new("membership_skipped_peers", "Number of providers skipped",).unwrap();
-    pub static ref MEMBERSHIP_ROUTABLE_PEERS: IntGauge =
-        IntGauge::new("membership_routable_peers", "Number of routable peers").unwrap();
-    pub static ref MEMBERSHIP_PROVIDER_PEERS: IntGauge =
-        IntGauge::new("membership_provider_peers", "Number of unique providers").unwrap();
-    pub static ref MEMBERSHIP_UNKNOWN_TOPIC: IntCounter = IntCounter::new(
-        "membership_unknown_topic",
-        "Number of messages with unknown topic"
-    )
-    .unwrap();
-    pub static ref MEMBERSHIP_INVALID_MESSAGE: IntCounter = IntCounter::new(
-        "membership_invalid_message",
-        "Number of invalid messages received"
-    )
-    .unwrap();
-    pub static ref MEMBERSHIP_PUBLISH_SUCCESS: IntCounter =
-        IntCounter::new("membership_publish_total", "Number of published messages").unwrap();
-    pub static ref MEMBERSHIP_PUBLISH_FAILURE: IntCounter = IntCounter::new(
-        "membership_publish_failure",
-        "Number of failed publish attempts"
-    )
-    .unwrap();
-    pub static ref CONTENT_RESOLVE_RUNNING: IntGauge = IntGauge::new(
-        "content_resolve_running",
-        "Number of currently running content resolutions"
-    )
-    .unwrap();
-    pub static ref CONTENT_RESOLVE_NO_PEERS: IntCounter = IntCounter::new(
-        "content_resolve_no_peers",
-        "Number of resolutions with no known peers"
-    )
-    .unwrap();
-    pub static ref CONTENT_RESOLVE_SUCCESS: IntCounter = IntCounter::new(
-        "content_resolve_success",
-        "Number of successful resolutions"
-    )
-    .unwrap();
-    pub static ref CONTENT_RESOLVE_FAILURE: IntCounter =
-        IntCounter::new("content_resolve_success", "Number of failed resolutions").unwrap();
-    pub static ref CONTENT_RESOLVE_FALLBACK: IntCounter = IntCounter::new(
-        "content_resolve_fallback",
-        "Number of resolutions that fall back on secondary peers"
-    )
-    .unwrap();
-    pub static ref CONTENT_RESOLVE_PEERS: Histogram = Histogram::with_opts(HistogramOpts::new(
-        "content_resolve_peers",
-        "Number of peers found for resolution from a subnet"
-    ))
-    .unwrap();
-    pub static ref CONTENT_CONNECTED_PEERS: Histogram = Histogram::with_opts(HistogramOpts::new(
-        "content_connected_peers",
-        "Number of connected peers in a resolution"
-    ))
-    .unwrap();
+macro_rules! metrics {
+    ($($name:ident : $type:ty = $make:expr);* $(;)?) => {
+        $(
+          lazy_static! {
+            pub static ref $name: $type = $make.unwrap();
+          }
+        )*
+
+        pub fn register_metrics(registry: &Registry) -> anyhow::Result<()> {
+          $(registry.register(Box::new($name.clone()))?;)*
+          Ok(())
+        }
+    };
 }
 
-pub fn register_metrics(registry: &Registry) -> anyhow::Result<()> {
-    registry.register(Box::new(PING_RTT.clone()))?;
-    registry.register(Box::new(PING_TIMEOUT.clone()))?;
-    registry.register(Box::new(PING_FAILURE.clone()))?;
-    registry.register(Box::new(PING_SUCCESS.clone()))?;
-    registry.register(Box::new(IDENTIFY_FAILURE.clone()))?;
-    registry.register(Box::new(IDENTIFY_RECEIVED.clone()))?;
-    registry.register(Box::new(DISCOVERY_BACKGROUND_LOOKUP.clone()))?;
-    registry.register(Box::new(DISCOVERY_CONNECTED_PEERS.clone()))?;
-    registry.register(Box::new(MEMBERSHIP_SKIPPED_PEERS.clone()))?;
-    registry.register(Box::new(MEMBERSHIP_ROUTABLE_PEERS.clone()))?;
-    registry.register(Box::new(MEMBERSHIP_PROVIDER_PEERS.clone()))?;
-    registry.register(Box::new(MEMBERSHIP_UNKNOWN_TOPIC.clone()))?;
-    registry.register(Box::new(MEMBERSHIP_INVALID_MESSAGE.clone()))?;
-    registry.register(Box::new(MEMBERSHIP_PUBLISH_SUCCESS.clone()))?;
-    registry.register(Box::new(MEMBERSHIP_PUBLISH_FAILURE.clone()))?;
-    registry.register(Box::new(CONTENT_RESOLVE_RUNNING.clone()))?;
-    registry.register(Box::new(CONTENT_RESOLVE_NO_PEERS.clone()))?;
-    registry.register(Box::new(CONTENT_RESOLVE_SUCCESS.clone()))?;
-    registry.register(Box::new(CONTENT_RESOLVE_FAILURE.clone()))?;
-    registry.register(Box::new(CONTENT_RESOLVE_FALLBACK.clone()))?;
-    registry.register(Box::new(CONTENT_RESOLVE_PEERS.clone()))?;
-    registry.register(Box::new(CONTENT_CONNECTED_PEERS.clone()))?;
-    Ok(())
+metrics! {
+    PING_RTT: Histogram =
+        Histogram::with_opts(HistogramOpts::new("ping_rtt", "Ping roundtrip time"));
+
+    PING_TIMEOUT: IntCounter =
+        IntCounter::new("ping_timeouts", "Number of timed out pings");
+
+    PING_FAILURE: IntCounter =
+        IntCounter::new("ping_failure", "Number of failed pings");
+
+    PING_SUCCESS: IntCounter =
+        IntCounter::new("ping_success", "Number of successful pings",);
+
+    IDENTIFY_FAILURE: IntCounter =
+        IntCounter::new("identify_failure", "Number of Identify errors",);
+
+    IDENTIFY_RECEIVED: IntCounter =
+        IntCounter::new("identify_received", "Number of Identify infos received",);
+
+    DISCOVERY_BACKGROUND_LOOKUP: IntCounter = IntCounter::new(
+        "discovery_background_lookup",
+        "Number of background lookups started",
+    );
+
+    DISCOVERY_CONNECTED_PEERS: IntGauge =
+        IntGauge::new("discovery_connected_peers", "Number of connections",);
+
+    MEMBERSHIP_SKIPPED_PEERS: IntCounter =
+        IntCounter::new("membership_skipped_peers", "Number of providers skipped",);
+
+    MEMBERSHIP_ROUTABLE_PEERS: IntGauge =
+        IntGauge::new("membership_routable_peers", "Number of routable peers");
+
+    MEMBERSHIP_PROVIDER_PEERS: IntGauge =
+        IntGauge::new("membership_provider_peers", "Number of unique providers");
+
+    MEMBERSHIP_UNKNOWN_TOPIC: IntCounter = IntCounter::new(
+        "membership_unknown_topic",
+        "Number of messages with unknown topic"
+    );
+
+    MEMBERSHIP_INVALID_MESSAGE: IntCounter = IntCounter::new(
+        "membership_invalid_message",
+        "Number of invalid messages received"
+    );
+
+    MEMBERSHIP_PUBLISH_SUCCESS: IntCounter = IntCounter::new(
+      "membership_publish_total", "Number of published messages"
+    );
+
+    MEMBERSHIP_PUBLISH_FAILURE: IntCounter = IntCounter::new(
+        "membership_publish_failure",
+        "Number of failed publish attempts"
+    );
+
+    CONTENT_RESOLVE_RUNNING: IntGauge = IntGauge::new(
+        "content_resolve_running",
+        "Number of currently running content resolutions"
+    );
+
+    CONTENT_RESOLVE_NO_PEERS: IntCounter = IntCounter::new(
+        "content_resolve_no_peers",
+        "Number of resolutions with no known peers"
+    );
+
+    CONTENT_RESOLVE_SUCCESS: IntCounter = IntCounter::new(
+        "content_resolve_success",
+        "Number of successful resolutions"
+    );
+
+    CONTENT_RESOLVE_FAILURE: IntCounter = IntCounter::new(
+      "content_resolve_success",
+      "Number of failed resolutions"
+    );
+
+    CONTENT_RESOLVE_FALLBACK: IntCounter = IntCounter::new(
+        "content_resolve_fallback",
+        "Number of resolutions that fall back on secondary peers"
+    );
+
+    CONTENT_RESOLVE_PEERS: Histogram = Histogram::with_opts(HistogramOpts::new(
+        "content_resolve_peers",
+        "Number of peers found for resolution from a subnet"
+    ));
+
+    CONTENT_CONNECTED_PEERS: Histogram = Histogram::with_opts(HistogramOpts::new(
+        "content_connected_peers",
+        "Number of connected peers in a resolution"
+    ));
 }


### PR DESCRIPTION
Closes #65 

The PR adds a bunch of Prometheus metrics to the library, and a `Service::register_metrics` method, similar to the one `Bitswap` has. 