### PR TITLE
IPC-86: Rate limit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,7 +72,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher 0.3.0",
  "cpufeatures",
  "opaque-debug",
@@ -84,7 +84,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher 0.4.3",
  "cpufeatures",
 ]
@@ -367,7 +367,7 @@ checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line 0.19.0",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object 0.30.3",
@@ -606,6 +606,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -616,7 +622,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c80e5460aa66fe3b91d40bcbdab953a597b60053e34d684ac6903f863b680a6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cipher 0.3.0",
  "cpufeatures",
  "zeroize",
@@ -720,7 +726,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
 dependencies = [
- "crossbeam-utils",
+ "crossbeam-utils 0.8.15",
 ]
 
 [[package]]
@@ -766,7 +772,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eeaa953eaad386a53111e47172c2fedba671e5684c8dd601a5f474f4f118710f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -888,7 +894,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -897,8 +903,8 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.15",
 ]
 
 [[package]]
@@ -907,9 +913,9 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.15",
 ]
 
 [[package]]
@@ -919,10 +925,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.15",
  "memoffset 0.8.0",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+dependencies = [
+ "cfg-if 0.1.10",
+ "crossbeam-utils 0.7.2",
+ "maybe-uninit",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+dependencies = [
+ "autocfg",
+ "cfg-if 0.1.10",
+ "lazy_static",
 ]
 
 [[package]]
@@ -931,7 +959,7 @@ version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1029,7 +1057,7 @@ version = "4.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da00a7a9a4eb92a0a0f8e75660926d48f0d0f3c537e455c457bcdaa1e16b1ac"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fiat-crypto",
  "packed_simd_2",
  "platforms",
@@ -1236,7 +1264,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -1249,6 +1277,15 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "discord-indexmap"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5ce88136a7c0378e34bb6b77881ec2d4159fdb6a8190f03ebe7b72117e50385"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1267,6 +1304,15 @@ name = "dtoa"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65d09067bfacaa79114679b279d7f5885b53295b1e2cfb4e79c8e4bd3d633169"
+
+[[package]]
+name = "dynamic-pool"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1474fbe84c305c3ff13c3f37b10de450fa56105ec8ea41bf5de1b578016d211f"
+dependencies = [
+ "crossbeam-queue",
+]
 
 [[package]]
 name = "ecdsa"
@@ -1337,7 +1383,7 @@ version = "0.8.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1881,6 +1927,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "gcra"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "369f8f7c230cdc510724482be4a0a4d899c504c74934e84ba5663f1820990413"
+dependencies = [
+ "thingvellir",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,7 +1962,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1907,7 +1973,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -1977,7 +2043,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.7",
  "tracing",
 ]
 
@@ -2288,7 +2354,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -2456,6 +2522,7 @@ dependencies = [
  "fvm_ipld_encoding 0.3.3",
  "fvm_ipld_hamt 0.6.1",
  "fvm_shared 3.0.0-alpha.17",
+ "gcra",
  "ipc-sdk",
  "lazy_static",
  "libipld",
@@ -3103,7 +3170,7 @@ dependencies = [
  "thiserror",
  "tinytemplate",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.7",
  "webrtc",
 ]
 
@@ -3203,7 +3270,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -3244,6 +3311,12 @@ name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "md-5"
@@ -3557,7 +3630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -3733,7 +3806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -3805,7 +3878,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1914cd452d8fccd6f9db48147b29fd4ae05bea9dc5d9ad578509f72415de282"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libm",
 ]
 
@@ -3842,7 +3915,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -3856,7 +3929,7 @@ version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -3974,7 +4047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "log",
  "wepoll-ffi",
@@ -3998,7 +4071,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
  "universal-hash 0.4.1",
@@ -4010,7 +4083,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ef234e08c11dfcb2e56f79fd70f6f2eb7f025c0ce2333e82f4f0518ecad30c6"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "opaque-debug",
  "universal-hash 0.5.0",
@@ -4102,7 +4175,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "memchr",
@@ -4360,7 +4433,7 @@ checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.15",
  "num_cpus",
 ]
 
@@ -4952,7 +5025,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -4964,7 +5037,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -4975,7 +5048,7 @@ version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -4987,7 +5060,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -4999,7 +5072,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.6",
 ]
@@ -5221,7 +5294,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fastrand",
  "redox_syscall",
  "rustix 0.36.9",
@@ -5255,6 +5328,26 @@ dependencies = [
  "log",
  "rustc-demangle",
  "tetsy-wasm",
+]
+
+[[package]]
+name = "thingvellir"
+version = "0.0.6-alpha1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f06f51fe804753b1eaf45b125f4b76d997cde80956b6b04ff9aa248d2a221826"
+dependencies = [
+ "anyhow",
+ "discord-indexmap",
+ "dynamic-pool",
+ "futures",
+ "fxhash",
+ "log",
+ "num_cpus",
+ "rand 0.8.5",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "tokio-util 0.6.10",
 ]
 
 [[package]]
@@ -5409,6 +5502,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "slab",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
@@ -5477,7 +5585,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -5511,7 +5619,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f7f83d1e4a0e4358ac54c5c3681e5d7da5efc5a7a632c90bb6d6669ddd9bc26"
 dependencies = [
  "async-trait",
- "cfg-if",
+ "cfg-if 1.0.0",
  "data-encoding",
  "enum-as-inner",
  "futures-channel",
@@ -5536,7 +5644,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aff21aa4dcefb0a1afbfac26deb0adc93888c7d295fb63ab273ef276ba2b7cfe"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "futures-util",
  "ipconfig",
  "lazy_static",
@@ -5834,7 +5942,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-tungstenite 0.17.2",
- "tokio-util",
+ "tokio-util 0.7.7",
  "tower-service",
  "tracing",
 ]
@@ -5857,7 +5965,7 @@ version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -5882,7 +5990,7 @@ version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -5973,7 +6081,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "bincode",
- "cfg-if",
+ "cfg-if 1.0.0",
  "indexmap",
  "lazy_static",
  "libc",
@@ -6079,7 +6187,7 @@ dependencies = [
  "addr2line 0.17.0",
  "anyhow",
  "bincode",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpp_demangle",
  "gimli 0.26.2",
  "ittapi-rs",
@@ -6117,7 +6225,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "indexmap",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433cfd6710c9986c576a25ca913c39d66a6474107b406f34f91d4a8923395241"
 dependencies = [
  "cfg-if 1.0.0",
- "cipher 0.4.3",
+ "cipher 0.4.4",
  "cpufeatures",
 ]
 
@@ -111,7 +111,7 @@ checksum = "82e1366e0c69c9f927b1fa5ce2c7bf9eafc8f9268c0b9800729e8b267612447c"
 dependencies = [
  "aead 0.5.1",
  "aes 0.8.2",
- "cipher 0.4.3",
+ "cipher 0.4.4",
  "ctr 0.9.2",
  "ghash 0.5.0",
  "subtle",
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.3"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
@@ -675,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1873270f8f7942c191139cb8a40fd228da6c3fd2fc376d7e92d47aa14aeb59e"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
@@ -1035,7 +1035,7 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.3",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1253,7 +1253,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer 0.10.4",
  "crypto-common",
  "subtle",
 ]
@@ -1475,9 +1475,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b2f3c51e4dd999930845da5d10a48775b8fe4ca9f4f9ec1f9161f334da5dfe"
+checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
 
 [[package]]
 name = "fil_actors_runtime"
@@ -2748,8 +2748,7 @@ dependencies = [
 [[package]]
 name = "libp2p-bitswap"
 version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d1cf3106f9aaed6a0098351e8dd98314ccc276cb847a82b032247f3e328346"
+source = "git+https://github.com/consensus-shipyard/libp2p-bitswap?branch=req-res-pub#8c544d0d2ef6a0919cfd4f7760a870d4d113f874"
 dependencies = [
  "async-trait",
  "fnv",
@@ -4042,16 +4041,18 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "polling"
-version = "2.5.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22122d5ec4f9fe1b3916419b76be1e80bcb93f618d071d2edf841b137b2a2bd6"
+checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
 dependencies = [
  "autocfg",
+ "bitflags",
  "cfg-if 1.0.0",
+ "concurrent-queue",
  "libc",
  "log",
- "wepoll-ffi",
- "windows-sys 0.42.0",
+ "pin-project-lite",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4906,9 +4907,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.153"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a382c72b4ba118526e187430bb4963cd6d55051ebf13d9b25574d379cc98d20"
+checksum = "8cdd151213925e7f1ab45a9bbfb129316bd00799784b174b7cc7bcd16961c49e"
 dependencies = [
  "serde_derive",
 ]
@@ -4933,9 +4934,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.153"
+version = "1.0.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ef476a5790f0f6decbc66726b6e5d63680ed518283e64c7df415989d880954f"
+checksum = "4fc80d722935453bcafdc2c9a73cd6fac4dc1938f0346035d84bf99fa9e33217"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5766,9 +5767,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "524b68aca1d05e03fdf03fcdce2c6c94b6daf6d16861ddaa7e4f2b6638a9052c"
 
 [[package]]
 name = "unicode-ident"
@@ -6516,15 +6517,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "winapi",
-]
-
-[[package]]
-name = "wepoll-ffi"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d743fdedc5c64377b5fc2bc036b01c7fd642205a0d96356034ae3404d49eb7fb"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -12,8 +12,7 @@ license-file.workspace = true
 anyhow = { workspace = true }
 blake2b_simd = { workspace = true }
 bloom = "0.3"
-thiserror = { workspace = true }
-tokio = { workspace = true }
+gcra = "0.3"
 lazy_static = { workspace = true }
 libp2p = { version = "0.50", default-features = false, features = [
   "gossipsub",
@@ -37,9 +36,11 @@ libp2p-bitswap = "0.25"
 libipld = { workspace = true }
 log = { workspace = true }
 prometheus = { workspace = true }
+quickcheck = { workspace = true, optional = true }
 rand = { workspace = true }
 serde = { workspace = true }
-quickcheck = { workspace = true, optional = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
 
 ipc-sdk = { workspace = true }
 fvm_ipld_encoding = { workspace = true }

--- a/ipld/resolver/Cargo.toml
+++ b/ipld/resolver/Cargo.toml
@@ -32,7 +32,6 @@ libp2p = { version = "0.50", default-features = false, features = [
   "secp256k1",
   "plaintext",
 ] }
-libp2p-bitswap = "0.25"
 libipld = { workspace = true }
 log = { workspace = true }
 prometheus = { workspace = true }
@@ -46,6 +45,10 @@ ipc-sdk = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
 fvm_shared = { workspace = true, optional = true }
 fvm_ipld_blockstore = { workspace = true, optional = true }
+
+# Using a fork of libp2p-bitswap so that we can do rate limiting.
+#libp2p-bitswap = "0.25"
+libp2p-bitswap = { git = "https://github.com/consensus-shipyard/libp2p-bitswap", branch = "req-res-pub" }
 
 [dev-dependencies]
 quickcheck = { workspace = true }

--- a/ipld/resolver/src/behaviour/content.rs
+++ b/ipld/resolver/src/behaviour/content.rs
@@ -11,6 +11,7 @@ use libipld::{store::StoreParams, Cid};
 use libp2p::{
     core::ConnectedPoint,
     futures::channel::oneshot,
+    multiaddr::Protocol,
     request_response::handler::RequestResponseHandlerEvent,
     swarm::{
         derive_prelude::{ConnectionId, FromSwarm},
@@ -189,15 +190,15 @@ impl<P: StoreParams> NetworkBehaviour for Behaviour<P> {
                 if c.other_established == 0 {
                     let peer_addr = match c.endpoint {
                         ConnectedPoint::Dialer {
-                            address: remote_addr,
+                            address: listen_addr,
                             ..
-                        } => remote_addr,
+                        } => listen_addr.clone(),
                         ConnectedPoint::Listener {
-                            send_back_addr: remote_addr,
+                            send_back_addr: ephemeral_addr,
                             ..
-                        } => remote_addr,
+                        } => select_non_ephemeral(ephemeral_addr.clone()),
                     };
-                    self.peer_addresses.insert(c.peer_id, peer_addr.clone());
+                    self.peer_addresses.insert(c.peer_id, peer_addr);
                 }
             }
             FromSwarm::ConnectionClosed(c) => {
@@ -205,6 +206,8 @@ impl<P: StoreParams> NetworkBehaviour for Behaviour<P> {
                     self.peer_addresses.remove(&c.peer_id);
                 }
             }
+            // Note: Ignoring FromSwarm::AddressChange - as long as the same peer connects,
+            // not updating the address provides continuity of resource consumption.
             _ => {}
         }
 
@@ -279,5 +282,54 @@ impl<P: StoreParams> NetworkBehaviour for Behaviour<P> {
         }
 
         Poll::Pending
+    }
+}
+
+/// Get rid of parts of an address which are considered ephemeral,
+/// keeping just the parts which would stay the same if for example
+/// the same peer opened another connection from a different random port.
+fn select_non_ephemeral(mut addr: Multiaddr) -> Multiaddr {
+    let mut keep = Vec::new();
+    while let Some(proto) = addr.pop() {
+        match proto {
+            // Some are valid on their own right.
+            Protocol::Ip4(_) | Protocol::Ip6(_) => {
+                keep.clear();
+                keep.push(proto);
+                break;
+            }
+            // Skip P2P peer ID, they might use a different identity.
+            Protocol::P2p(_) => {}
+            // Skip ephemeral parts.
+            Protocol::Tcp(_) | Protocol::Udp(_) => {}
+            // Everything else we keep until we see better options.
+            _ => {
+                keep.push(proto);
+            }
+        }
+    }
+    keep.reverse();
+    Multiaddr::from_iter(keep.into_iter())
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::Multiaddr;
+
+    use super::select_non_ephemeral;
+
+    #[test]
+    fn non_ephemeral_addr() {
+        let examples = [
+            ("/ip4/127.0.0.1/udt/sctp/5678", "/ip4/127.0.0.1"),
+            ("/ip4/95.217.194.97/tcp/8008/p2p/12D3KooWC1EaEEpghwnPdd89LaPTKEweD1PRLz4aRBkJEA9UiUuS", "/ip4/95.217.194.97"),
+            ("/udt/memory/10/p2p/12D3KooWC1EaEEpghwnPdd89LaPTKEweD1PRLz4aRBkJEA9UiUuS", "/udt/memory/10")
+        ];
+
+        for (addr, exp) in examples {
+            let addr: Multiaddr = addr.parse().unwrap();
+            let exp: Multiaddr = exp.parse().unwrap();
+            assert_eq!(select_non_ephemeral(addr), exp);
+        }
     }
 }

--- a/ipld/resolver/src/behaviour/content.rs
+++ b/ipld/resolver/src/behaviour/content.rs
@@ -1,10 +1,16 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 
-use std::task::{Context, Poll};
+use std::{
+    collections::HashMap,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use libipld::{store::StoreParams, Cid};
 use libp2p::{
+    core::ConnectedPoint,
+    request_response::handler::RequestResponseHandlerEvent,
     swarm::{
         derive_prelude::{ConnectionId, FromSwarm},
         ConnectionHandler, IntoConnectionHandler, NetworkBehaviour, NetworkBehaviourAction,
@@ -13,9 +19,13 @@ use libp2p::{
     Multiaddr, PeerId,
 };
 use libp2p_bitswap::{Bitswap, BitswapConfig, BitswapEvent, BitswapStore};
+use log::warn;
 use prometheus::Registry;
 
-use crate::stats;
+use crate::{
+    limiter::{RateLimit, RateLimiter},
+    stats,
+};
 
 pub type QueryId = libp2p_bitswap::QueryId;
 
@@ -39,18 +49,42 @@ pub enum Event {
     Complete(QueryId, anyhow::Result<()>),
 }
 
+/// Configuration for [`content::Behaviour`].
+#[derive(Debug, Clone)]
+pub struct Config {
+    /// Number of bytes that can be consumed remote peers in a time period.
+    ///
+    /// 0 means no limit.
+    pub rate_limit_bytes: u32,
+    /// Length of the time period at which the consumption limit fills.
+    ///
+    /// 0 means no limit.
+    pub rate_limit_period: Duration,
+}
+
 /// Behaviour built on [`Bitswap`] to resolve IPLD content from [`Cid`] to raw bytes.
 pub struct Behaviour<P: StoreParams> {
     inner: Bitswap<P>,
+    /// Remember which address peers connected from, so we can apply the rate limit
+    /// on the address, and not on the peer ID which they can change easily.
+    peer_addresses: HashMap<PeerId, Multiaddr>,
+    /// Limit the amount of data served by remote address.
+    rate_limiter: RateLimiter<Multiaddr>,
+    rate_limit: RateLimit,
 }
 
 impl<P: StoreParams> Behaviour<P> {
-    pub fn new<S>(store: S) -> Self
+    pub fn new<S>(config: Config, store: S) -> Self
     where
         S: BitswapStore<Params = P>,
     {
         let bitswap = Bitswap::new(BitswapConfig::default(), store);
-        Self { inner: bitswap }
+        Self {
+            inner: bitswap,
+            peer_addresses: Default::default(),
+            rate_limiter: RateLimiter::new(config.rate_limit_period),
+            rate_limit: RateLimit::new(config.rate_limit_bytes, config.rate_limit_period),
+        }
     }
 
     /// Register Prometheus metrics.
@@ -83,6 +117,26 @@ impl<P: StoreParams> Behaviour<P> {
         // Not passing any missing items, which will result in a call to `BitswapStore::missing_blocks`.
         self.inner.sync(cid, peers, [].into_iter())
     }
+
+    /// Check if we are using rate limiting.
+    fn has_rate_limits(&self) -> bool {
+        !(self.rate_limit.resource_limit == 0 || self.rate_limit.period.is_zero())
+    }
+
+    /// Check whether the peer has already exhaused their rate limit.
+    fn check_rate_limit(&mut self, peer_id: &PeerId, cid: &Cid) -> bool {
+        if !self.has_rate_limits() {
+            return true;
+        }
+        if let Some(addr) = self.peer_addresses.get(peer_id).cloned() {
+            let bytes = cid.to_bytes().len().try_into().unwrap_or(u32::MAX);
+
+            if !self.rate_limiter.add(&self.rate_limit, addr, bytes) {
+                return false;
+            }
+        }
+        true
+    }
 }
 
 impl<P: StoreParams> NetworkBehaviour for Behaviour<P> {
@@ -98,6 +152,31 @@ impl<P: StoreParams> NetworkBehaviour for Behaviour<P> {
     }
 
     fn on_swarm_event(&mut self, event: FromSwarm<Self::ConnectionHandler>) {
+        // Store the remote address.
+        match &event {
+            FromSwarm::ConnectionEstablished(c) => {
+                if c.other_established == 0 {
+                    let peer_addr = match c.endpoint {
+                        ConnectedPoint::Dialer {
+                            address: remote_addr,
+                            ..
+                        } => remote_addr,
+                        ConnectedPoint::Listener {
+                            send_back_addr: remote_addr,
+                            ..
+                        } => remote_addr,
+                    };
+                    self.peer_addresses.insert(c.peer_id, peer_addr.clone());
+                }
+            }
+            FromSwarm::ConnectionClosed(c) => {
+                if c.remaining_established == 0 {
+                    self.peer_addresses.remove(&c.peer_id);
+                }
+            }
+            _ => {}
+        }
+
         self.inner.on_swarm_event(event)
     }
 
@@ -107,6 +186,14 @@ impl<P: StoreParams> NetworkBehaviour for Behaviour<P> {
         connection_id: ConnectionId,
         event: <<Self::ConnectionHandler as IntoConnectionHandler>::Handler as ConnectionHandler>::OutEvent,
     ) {
+        if let RequestResponseHandlerEvent::Request { request, .. } = &event {
+            if !self.check_rate_limit(&peer_id, &request.cid) {
+                warn!("rate limiting {peer_id}");
+                stats::CONTENT_RATE_LIMITED.inc();
+                return;
+            }
+        }
+
         self.inner
             .on_connection_handler_event(peer_id, connection_id, event)
     }

--- a/ipld/resolver/src/behaviour/content.rs
+++ b/ipld/resolver/src/behaviour/content.rs
@@ -163,6 +163,11 @@ impl<P: StoreParams> Behaviour<P> {
             }
         }
     }
+
+    /// Update the rate limit to a new value, keeping the period as-is.
+    pub fn update_rate_limit(&mut self, bytes: u32) {
+        self.rate_limit = RateLimit::new(bytes, self.rate_limit.period)
+    }
 }
 
 impl<P: StoreParams> NetworkBehaviour for Behaviour<P> {

--- a/ipld/resolver/src/behaviour/mod.rs
+++ b/ipld/resolver/src/behaviour/mod.rs
@@ -14,6 +14,7 @@ pub mod content;
 pub mod discovery;
 pub mod membership;
 
+pub use content::Config as ContentConfig;
 pub use discovery::Config as DiscoveryConfig;
 pub use membership::Config as MembershipConfig;
 
@@ -67,6 +68,7 @@ impl<P: StoreParams> Behaviour<P> {
         nc: NetworkConfig,
         dc: DiscoveryConfig,
         mc: MembershipConfig,
+        cc: ContentConfig,
         store: S,
     ) -> Result<Self, ConfigError>
     where
@@ -80,7 +82,7 @@ impl<P: StoreParams> Behaviour<P> {
             )),
             discovery: discovery::Behaviour::new(nc.clone(), dc)?,
             membership: membership::Behaviour::new(nc, mc)?,
-            content: content::Behaviour::new(store),
+            content: content::Behaviour::new(cc, store),
         })
     }
 

--- a/ipld/resolver/src/lib.rs
+++ b/ipld/resolver/src/lib.rs
@@ -14,5 +14,5 @@ mod arb;
 #[cfg(feature = "missing_blocks")]
 pub mod missing_blocks;
 
-pub use behaviour::{DiscoveryConfig, MembershipConfig, NetworkConfig};
+pub use behaviour::{ContentConfig, DiscoveryConfig, MembershipConfig, NetworkConfig};
 pub use service::{Client, Config, ConnectionConfig, NoKnownPeers, Service};

--- a/ipld/resolver/src/lib.rs
+++ b/ipld/resolver/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 mod behaviour;
 mod hash;
+mod limiter;
 mod provider_cache;
 mod provider_record;
 mod service;

--- a/ipld/resolver/src/limiter.rs
+++ b/ipld/resolver/src/limiter.rs
@@ -39,10 +39,7 @@ where
 
     /// Same as [`RateLimiter::add`] but allows passing in the time, for testing.
     pub fn add_at(&mut self, limit: &RateLimit, key: K, cost: u32, at: Instant) -> bool {
-        let state = self
-            .cache
-            .entry(key)
-            .or_insert_with(|| GcraState::default());
+        let state = self.cache.entry(key).or_insert_with(GcraState::default);
 
         state.check_and_modify_at(limit, at, cost).is_ok()
     }
@@ -61,21 +58,18 @@ mod tests {
         let rate_limit = RateLimit::new(10 * 1024 * 1024, one_hour);
         let mut rate_limiter = RateLimiter::<&'static str>::new(one_hour);
 
-        assert_eq!(true, rate_limiter.add(&rate_limit, "foo", 1024));
-        assert_eq!(true, rate_limiter.add(&rate_limit, "foo", 5 * 1024 * 1024));
-        assert_eq!(
-            false,
-            rate_limiter.add(&rate_limit, "foo", 5 * 1024 * 1024),
+        assert!(rate_limiter.add(&rate_limit, "foo", 1024));
+        assert!(rate_limiter.add(&rate_limit, "foo", 5 * 1024 * 1024));
+        assert!(
+            !rate_limiter.add(&rate_limit, "foo", 5 * 1024 * 1024),
             "can't over consume"
         );
-        assert_eq!(
-            true,
+        assert!(
             rate_limiter.add(&rate_limit, "bar", 5 * 1024 * 1024),
             "others can consume"
         );
 
-        assert_eq!(
-            true,
+        assert!(
             rate_limiter.add_at(
                 &rate_limit,
                 "foo",
@@ -86,8 +80,7 @@ mod tests {
         );
 
         let rate_limit = RateLimit::new(50 * 1024 * 1024, one_hour);
-        assert_eq!(
-            true,
+        assert!(
             rate_limiter.add(&rate_limit, "bar", 15 * 1024 * 1024),
             "can raise quota"
         );

--- a/ipld/resolver/src/limiter.rs
+++ b/ipld/resolver/src/limiter.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
 use std::hash::Hash;
 use std::time::{Duration, Instant};
 

--- a/ipld/resolver/src/limiter.rs
+++ b/ipld/resolver/src/limiter.rs
@@ -1,0 +1,93 @@
+use std::hash::Hash;
+use std::time::{Duration, Instant};
+
+use gcra::GcraState;
+pub use gcra::RateLimit;
+use libp2p::gossipsub::time_cache::TimeCache;
+
+/// Track the rate limit of resources (e.g. bytes) consumed per key.
+///
+/// Forgets keys after long periods of inactivity.
+pub struct RateLimiter<K> {
+    // `TimeCache` uses `Instant::now()` internally.
+    // It's less testable than `gcra` which allows the time to be passed in,
+    // but it's only used for cleaning up, so it should be okay.
+    cache: TimeCache<K, GcraState>,
+}
+
+impl<K> RateLimiter<K>
+where
+    K: Eq + Hash + Clone,
+{
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            cache: TimeCache::new(ttl),
+        }
+    }
+
+    /// Try to add a certain amount of resources consumed to a key.
+    ///
+    /// Return `true` if the key was within limits, `false` if it needs to wait.
+    ///
+    /// The [`RateLimit`] is passed in so that we can update it dynamically
+    /// based on how much data we anticipate we will have to serve.
+    pub fn add(&mut self, limit: &RateLimit, key: K, cost: u32) -> bool {
+        self.add_at(limit, key, cost, Instant::now())
+    }
+
+    /// Same as [`RateLimiter::add`] but allows passing in the time, for testing.
+    pub fn add_at(&mut self, limit: &RateLimit, key: K, cost: u32, at: Instant) -> bool {
+        let state = self
+            .cache
+            .entry(key)
+            .or_insert_with(|| GcraState::default());
+
+        state.check_and_modify_at(limit, at, cost).is_ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, Instant};
+
+    use super::{RateLimit, RateLimiter};
+
+    #[test]
+    fn basics() {
+        // 10Mb per hour.
+        let one_hour = Duration::from_secs(60 * 60);
+        let rate_limit = RateLimit::new(10 * 1024 * 1024, one_hour);
+        let mut rate_limiter = RateLimiter::<&'static str>::new(one_hour);
+
+        assert_eq!(true, rate_limiter.add(&rate_limit, "foo", 1024));
+        assert_eq!(true, rate_limiter.add(&rate_limit, "foo", 5 * 1024 * 1024));
+        assert_eq!(
+            false,
+            rate_limiter.add(&rate_limit, "foo", 5 * 1024 * 1024),
+            "can't over consume"
+        );
+        assert_eq!(
+            true,
+            rate_limiter.add(&rate_limit, "bar", 5 * 1024 * 1024),
+            "others can consume"
+        );
+
+        assert_eq!(
+            true,
+            rate_limiter.add_at(
+                &rate_limit,
+                "foo",
+                5 * 1024 * 1024,
+                Instant::now() + one_hour + Duration::from_secs(1)
+            ),
+            "can consume again in the future"
+        );
+
+        let rate_limit = RateLimit::new(50 * 1024 * 1024, one_hour);
+        assert_eq!(
+            true,
+            rate_limiter.add(&rate_limit, "bar", 15 * 1024 * 1024),
+            "can raise quota"
+        );
+    }
+}

--- a/ipld/resolver/src/service.rs
+++ b/ipld/resolver/src/service.rs
@@ -26,8 +26,8 @@ use tokio::select;
 use tokio::sync::oneshot::{self, Sender};
 
 use crate::behaviour::{
-    self, content, discovery, membership, Behaviour, BehaviourEvent, ConfigError, DiscoveryConfig,
-    MembershipConfig, NetworkConfig,
+    self, content, discovery, membership, Behaviour, BehaviourEvent, ConfigError, ContentConfig,
+    DiscoveryConfig, MembershipConfig, NetworkConfig,
 };
 use crate::stats;
 
@@ -73,6 +73,7 @@ pub struct Config {
     pub discovery: DiscoveryConfig,
     pub membership: MembershipConfig,
     pub connection: ConnectionConfig,
+    pub content: ContentConfig,
 }
 
 /// Internal requests to enqueue to the [`Service`]
@@ -176,7 +177,13 @@ impl<P: StoreParams> Service<P> {
     {
         let peer_id = config.network.local_peer_id();
         let transport = transport(config.network.local_key.clone());
-        let behaviour = Behaviour::new(config.network, config.discovery, config.membership, store)?;
+        let behaviour = Behaviour::new(
+            config.network,
+            config.discovery,
+            config.membership,
+            config.content,
+            store,
+        )?;
 
         // NOTE: Hardcoded values from Forest. Will leave them as is until we know we need to change.
 

--- a/ipld/resolver/src/stats.rs
+++ b/ipld/resolver/src/stats.rs
@@ -107,4 +107,9 @@ metrics! {
         "content_connected_peers",
         "Number of connected peers in a resolution"
     ));
+
+    CONTENT_RATE_LIMITED: IntCounter = IntCounter::new(
+        "content_rate_limited",
+        "Number of rate limited requests"
+    );
 }

--- a/ipld/resolver/tests/smoke.rs
+++ b/ipld/resolver/tests/smoke.rs
@@ -23,7 +23,8 @@ use anyhow::anyhow;
 use fvm_ipld_hamt::Hamt;
 use fvm_shared::{address::Address, ActorID};
 use ipc_ipld_resolver::{
-    Client, Config, ConnectionConfig, DiscoveryConfig, MembershipConfig, NetworkConfig, Service,
+    Client, Config, ConnectionConfig, ContentConfig, DiscoveryConfig, MembershipConfig,
+    NetworkConfig, Service,
 };
 use ipc_sdk::subnet_id::{SubnetID, ROOTNET_ID};
 use libipld::Cid;
@@ -187,6 +188,10 @@ fn make_config(rng: &mut StdRng, cluster_size: u32, bootstrap_addr: Option<Multi
             publish_interval: Duration::from_secs(5),
             min_time_between_publish: Duration::from_secs(1),
             max_provider_age: Duration::from_secs(60),
+        },
+        content: ContentConfig {
+            rate_limit_bytes: 1 << 20,
+            rate_limit_period: Duration::from_secs(60),
         },
     };
 


### PR DESCRIPTION
Closes #86 

The PR uses the [gcra](https://crates.io/crates/gcra) library to rate limit the amount of data that can go to any individual `MultiAddress` via `Bitswap`. The `content::Config` gets two new fields, `rate_limit_bytes` and `rate_limit_period`, so that we can configure e.g. that any peer cannot download more than 10MB/hour from us. 

The `Client` has a new `update_rate_limit` method we can use to adjust this value on the fly, if we see that this is going to be too tight. The `gcra` library was picked because it allows passing in the limit with each request, unlike for example the [governor](https://crates.io/crates/governor). 

To make it work, I had to fork `libp2p-bitswap`, because normally it sends the response straight to the connection handler, which writes it to the socket. To inspect the response, I had to redirect the channels, which required the hitherto private `BitswapResponse` type to be public. 

I see that `libp2p-bitswap` has metrics like `THROTTLED_INBOUND`, however, they aren't used. This suggests that rate limiting was supposed to be part of the library, but apart from https://github.com/ipfs-rust/libp2p-bitswap/issues/22 saying it's a bit naive at the moment, I didn't find anything on this. I thought making the aforementioned type public is the lightest touch. 

Another option which would have resulted in much less code and indirection on our part would have been to extend the `BitswapEvent` to not only report progress on our own queries, but the responses sent. I didn't want to break the API for anyone who uses this library, without talking to the devs, though. Maybe they would prefer to add throttling directly.