### PR TITLE
set network

### DIFF
--- a/config/template.toml
+++ b/config/template.toml
@@ -1,6 +1,5 @@
 [server]
 json_rpc_address = "127.0.0.1:3030"
-network = 1 # we are in the test network, 0 is mainnet
 
 [subnets]
 

--- a/src/config/deserialize.rs
+++ b/src/config/deserialize.rs
@@ -2,9 +2,8 @@
 // SPDX-License-Identifier: MIT
 //! Deserialization utils for config mod.
 
-use fvm_shared::address::{Address, Network};
+use fvm_shared::address::Address;
 use ipc_sdk::subnet_id::SubnetID;
-use num_traits::FromPrimitive;
 use serde::de::{Error, SeqAccess};
 use serde::Deserializer;
 use std::fmt::Formatter;
@@ -31,31 +30,6 @@ where
         }
     }
     deserializer.deserialize_str(SubnetIDVisitor)
-}
-
-/// A serde deserialization method to deserialize a u8 into a [`Network`].
-pub(crate) fn deserialize_network<'de, D>(deserializer: D) -> anyhow::Result<Network, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    struct NetworkVisitor;
-    impl<'de> serde::de::Visitor<'de> for NetworkVisitor {
-        type Value = Network;
-
-        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
-            formatter.write_str("a i64")
-        }
-
-        // We only need u8, but toml integer is mapped to serde with i64.
-        // If we use u8, it will throw an error.
-        fn visit_i64<E>(self, v: i64) -> std::result::Result<Self::Value, E>
-        where
-            E: Error,
-        {
-            Network::from_u8(v as u8).ok_or_else(|| Error::custom("unknown network"))
-        }
-    }
-    deserializer.deserialize_str(NetworkVisitor)
 }
 
 /// A serde deserialization method to deserialize a list of account strings into a vector of

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -1,7 +1,5 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
-use crate::config::deserialize::deserialize_network;
-use fvm_shared::address::Network;
 use serde::Deserialize;
 use std::net::SocketAddr;
 
@@ -10,8 +8,6 @@ pub const JSON_RPC_ENDPOINT: &str = "json_rpc";
 #[derive(Deserialize, Clone, Debug)]
 pub struct Server {
     pub json_rpc_address: SocketAddr,
-    #[serde(deserialize_with = "deserialize_network")]
-    pub network: Network,
 }
 
 pub mod json_rpc_methods {

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -125,7 +125,6 @@ fn config_str() -> String {
         r#"
             [server]
             json_rpc_address = "{SERVER_JSON_RPC_ADDR}"
-            network = 0
 
             [subnets]
             [subnets.root]
@@ -147,7 +146,6 @@ fn config_str_diff_addr() -> String {
         r#"
             [server]
             json_rpc_address = "127.0.0.1:3031"
-            network = 0
 
             [subnets]
             [subnets.root]
@@ -169,7 +167,6 @@ fn read_config() -> Config {
         r#"
             [server]
             json_rpc_address = "{SERVER_JSON_RPC_ADDR}"
-            network = 0
 
             [subnets]
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,21 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
+use fvm_shared::address::{set_current_network, Network};
 use ipc_agent::cli;
+use num_traits::FromPrimitive;
 
 #[tokio::main]
 async fn main() {
     env_logger::init_from_env(env_logger::Env::new().default_filter_or("info"));
+
+    let network_raw: u8 = std::env::var("LOTUS_NETWORK")
+        // default to testnet
+        .unwrap_or_else(|_| String::from("1"))
+        .parse()
+        .unwrap();
+    let network = Network::from_u8(network_raw).unwrap();
+    log::debug!("using network: {network:?}");
+    set_current_network(network);
+
     cli::cli().await;
 }

--- a/src/server/jsonrpc.rs
+++ b/src/server/jsonrpc.rs
@@ -8,7 +8,6 @@ use crate::server::Handlers;
 use anyhow::Result;
 use bytes::Bytes;
 
-use fvm_shared::address::set_current_network;
 use std::sync::Arc;
 use warp::http::StatusCode;
 use warp::reject::Reject;
@@ -59,9 +58,6 @@ impl JsonRPCServer {
             "IPC agent rpc node listening at {:?}",
             self.config.server.json_rpc_address
         );
-
-        // need to set network, otherwise Address::from_str will throw error.
-        set_current_network(self.config.server.network);
 
         let handlers = Arc::new(Handlers::new(self.default_config_path.clone())?);
         warp::serve(json_rpc_filter(handlers))


### PR DESCRIPTION
Setting the network from env variable. This is because in the config, it's deserializing based on a network, if the network is not set, it will give an error.