### PR TITLE
Fix serialization for list-subnets

### DIFF
--- a/src/cli/commands/manager/create.rs
+++ b/src/cli/commands/manager/create.rs
@@ -44,7 +44,11 @@ impl CommandLineHandler for CreateSubnet {
             .await?
             .address;
 
-        log::info!("created subnet actor with address: {address:}");
+        log::info!(
+            "created subnet actor with id: {}/{}",
+            arguments.parent,
+            address
+        );
 
         Ok(())
     }

--- a/src/lotus/message/deserialize.rs
+++ b/src/lotus/message/deserialize.rs
@@ -3,6 +3,7 @@
 //! Deserialization utils for lotus/ipc types.
 
 use fvm_shared::address::Address;
+use fvm_shared::bigint::BigInt;
 use fvm_shared::econ::TokenAmount;
 use ipc_sdk::subnet_id::SubnetID;
 use serde::de::{Error, MapAccess};
@@ -87,7 +88,7 @@ where
         where
             E: Error,
         {
-            let u: u64 = v.parse().map_err(E::custom)?;
+            let u = BigInt::from_str(v).map_err(E::custom)?;
             Ok(TokenAmount::from_atto(u))
         }
     }

--- a/src/lotus/message/ipc.rs
+++ b/src/lotus/message/ipc.rs
@@ -41,6 +41,7 @@ pub struct IPCReadSubnetActorStateResponse {
 pub struct SubnetInfo {
     /// Id of the subnet.
     #[serde(deserialize_with = "deserialize_subnet_id_from_map")]
+    #[serde(rename = "ID")]
     pub id: SubnetID,
     /// Collateral staked in the subnet.
     #[serde(deserialize_with = "deserialize_token_amount_from_str")]

--- a/src/lotus/message/ipc.rs
+++ b/src/lotus/message/ipc.rs
@@ -37,6 +37,7 @@ pub struct IPCReadSubnetActorStateResponse {
 
 /// SubnetInfo is an auxiliary struct that collects relevant information about the state of a subnet
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 pub struct SubnetInfo {
     /// Id of the subnet.
     #[serde(deserialize_with = "deserialize_subnet_id_from_map")]
@@ -46,6 +47,7 @@ pub struct SubnetInfo {
     pub stake: TokenAmount,
     /// Circulating supply available in the subnet.
     #[serde(deserialize_with = "deserialize_token_amount_from_str")]
+    #[serde(rename = "CircSupply")]
     pub circ_supply: TokenAmount,
     /// State of the Subnet (Initialized, Active, Killed)
     pub status: Status,

--- a/src/lotus/message/tests.rs
+++ b/src/lotus/message/tests.rs
@@ -71,10 +71,10 @@ fn test_token_amount_from_str() {
 
     let raw_str = r#"
     {
-        "TokenAmount": "1000000000000000000"
+        "TokenAmount": "20000000000000000000"
     }"#;
 
     let w: Result<Wrapper, _> = serde_json::from_str(raw_str);
     assert!(w.is_ok());
-    assert_eq!(w.unwrap().token_amount, TokenAmount::from_whole(1));
+    assert_eq!(w.unwrap().token_amount, TokenAmount::from_whole(20));
 }


### PR DESCRIPTION
Adds a set of fixes to make `list-subnets` actually work after the fixes in its Go counterpart.

@cryptoAtwill if there is no major comment, feel free to merge as soon as you approve to move fast :pray: 