### PR TITLE
Inject ReloadableConfig into JsonRPCServer

### DIFF
--- a/src/cli/commands/daemon.rs
+++ b/src/cli/commands/daemon.rs
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: MIT
 //! The Daemon command line handler that prints the info about IPC Agent.
 
+use std::fmt::Debug;
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use clap::Args;
-use std::fmt::Debug;
 
 use crate::cli::{CommandLineHandler, GlobalArguments};
+use crate::config::ReloadableConfig;
 use crate::server::jsonrpc::JsonRPCServer;
 
 /// The command to start the ipc agent json rpc server in the foreground.
@@ -23,10 +26,9 @@ impl CommandLineHandler for LaunchDaemon {
             global
         );
 
-        let server = JsonRPCServer::from_config_path(&global.config_path()).map_err(|e| {
-            log::error!("error getting config from path");
-            e
-        })?;
+        let reloadable_config = Arc::new(ReloadableConfig::new(global.config_path())?);
+
+        let server = JsonRPCServer::new(reloadable_config);
         server.run().await?;
 
         Ok(())

--- a/src/config/reload.rs
+++ b/src/config/reload.rs
@@ -5,7 +5,6 @@
 use crate::config::Config;
 use anyhow::Result;
 use std::ops::DerefMut;
-use std::path::Path;
 use std::sync::{Arc, RwLock};
 use tokio::sync::broadcast;
 
@@ -14,6 +13,7 @@ use tokio::sync::broadcast;
 /// needs to be notified when config has updated, just make a new subscription. Once received a
 /// notification, read the config again to obtain the latest config.
 pub struct ReloadableConfig {
+    path: RwLock<Arc<String>>,
     config: RwLock<Arc<Config>>,
     broadcast_tx: broadcast::Sender<()>,
     /// We keep at least one channel active, so that we dont encounter a `SendError`. We might need to use it later.
@@ -22,13 +22,14 @@ pub struct ReloadableConfig {
 }
 
 impl ReloadableConfig {
-    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+    pub fn new(path: String) -> Result<Self> {
         // we dont really need a big channel, the frequency should be very very low
         let (broadcast_tx, broadcast_rx) = broadcast::channel(8);
 
-        let config = RwLock::new(Arc::new(Config::from_file(path)?));
+        let config = RwLock::new(Arc::new(Config::from_file(path.clone())?));
 
         Ok(Self {
+            path: RwLock::new(Arc::new(path)),
             config,
             broadcast_tx,
             broadcast_rx,
@@ -41,8 +42,15 @@ impl ReloadableConfig {
         config.clone()
     }
 
-    /// Triggers a reload of the config from the target path
-    pub async fn reload(&self, path: String) -> Result<()> {
+    /// Sets a new path for future reloads.
+    pub fn set_path(&self, path: String) {
+        let mut p = self.path.write().unwrap();
+        *p = Arc::new(path);
+    }
+
+    /// Triggers a reload of the config.
+    pub async fn reload(&self) -> Result<()> {
+        let path = self.path.read().unwrap().to_string();
         let new_config = Config::from_file_async(path).await?;
         log::info!("new config loaded: {new_config:?}");
 

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -50,7 +50,7 @@ async fn reload_works() {
     let h_cloned = h.clone();
     tokio::spawn(async move {
         {
-            let &(ref lock, ref cvar) = &*pair;
+            let (lock, cvar) = &*pair;
             let mut started = lock.lock().unwrap();
             while !*started {
                 started = cvar.wait(started).unwrap();
@@ -68,7 +68,7 @@ async fn reload_works() {
 
     let mut rx = h.new_subscriber();
     {
-        let &(ref lock, ref cvar) = &*pair2;
+        let (lock, cvar) = &*pair2;
         let mut started = lock.lock().unwrap();
         *started = true;
         cvar.notify_one();

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -62,7 +62,8 @@ async fn reload_works() {
         let mut file = file.reopen().unwrap();
         file.write_all(config_str.as_bytes()).unwrap();
 
-        h_cloned.reload(path).await.unwrap();
+        h_cloned.set_path(path);
+        h_cloned.reload().await.unwrap();
     });
 
     let mut rx = h.new_subscriber();

--- a/src/manager/checkpoint.rs
+++ b/src/manager/checkpoint.rs
@@ -33,7 +33,7 @@ use crate::lotus::LotusClient;
 const CHAIN_HEAD_REQUEST_PERIOD: Duration = Duration::from_secs(10);
 
 /// The `CheckpointSubsystem`. When run, it actively monitors subnets and submits checkpoints.
-struct CheckpointSubsystem {
+pub struct CheckpointSubsystem {
     /// The subsystem uses a `ReloadableConfig` to ensure that, at all, times, the subnets under
     /// management are those in the latest version of the config.
     config: ReloadableConfig,
@@ -41,8 +41,7 @@ struct CheckpointSubsystem {
 
 impl CheckpointSubsystem {
     /// Creates a new `CheckpointSubsystem` with a configuration `config`.
-    #[allow(dead_code)]
-    fn new(config: ReloadableConfig) -> Self {
+    pub fn new(config: ReloadableConfig) -> Self {
         Self { config }
     }
 

--- a/src/manager/checkpoint.rs
+++ b/src/manager/checkpoint.rs
@@ -36,12 +36,13 @@ const CHAIN_HEAD_REQUEST_PERIOD: Duration = Duration::from_secs(10);
 pub struct CheckpointSubsystem {
     /// The subsystem uses a `ReloadableConfig` to ensure that, at all, times, the subnets under
     /// management are those in the latest version of the config.
-    config: ReloadableConfig,
+    config: Arc<ReloadableConfig>,
 }
 
 impl CheckpointSubsystem {
     /// Creates a new `CheckpointSubsystem` with a configuration `config`.
-    pub fn new(config: ReloadableConfig) -> Self {
+    #[allow(dead_code)]
+    pub fn new(config: Arc<ReloadableConfig>) -> Self {
         Self { config }
     }
 

--- a/src/server/handlers/config.rs
+++ b/src/server/handlers/config.rs
@@ -16,15 +16,11 @@ pub struct ReloadConfigParams {
 /// The create subnet json rpc method handler.
 pub(crate) struct ReloadConfigHandler {
     config: Arc<ReloadableConfig>,
-    default_config_path: String,
 }
 
 impl ReloadConfigHandler {
-    pub fn new(config: Arc<ReloadableConfig>, default_config_path: String) -> Self {
-        Self {
-            config,
-            default_config_path,
-        }
+    pub fn new(config: Arc<ReloadableConfig>) -> Self {
+        Self { config }
     }
 }
 
@@ -36,9 +32,9 @@ impl JsonRPCRequestHandler for ReloadConfigHandler {
     async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
         log::info!("received request to reload config: {request:?}");
 
-        let path = request
-            .path
-            .unwrap_or_else(|| self.default_config_path.clone());
-        self.config.reload(path).await
+        if request.path.is_some() {
+            self.config.set_path(request.path.unwrap());
+        }
+        self.config.reload().await
     }
 }

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -61,12 +61,10 @@ impl Handlers {
         }
     }
 
-    pub fn new(config_path_string: String) -> Result<Self> {
+    pub fn new(config: Arc<ReloadableConfig>) -> Result<Self> {
         let mut handlers = HashMap::new();
 
-        let config = Arc::new(ReloadableConfig::new(config_path_string.clone())?);
-        let h: Box<dyn HandlerWrapper> =
-            Box::new(ReloadConfigHandler::new(config.clone(), config_path_string));
+        let h: Box<dyn HandlerWrapper> = Box::new(ReloadConfigHandler::new(config.clone()));
         handlers.insert(String::from(json_rpc_methods::RELOAD_CONFIG), h);
 
         // subnet manager methods


### PR DESCRIPTION
This injects the ReloadableConfig as a constructor parameter into the JsonRPCServer as opposed to having the JsonRPCServer constructing it. The allows the ReloadableConfig to be resued by other components. In particular, it will allow the CheckpointSubsystem to use it.
