### PR TITLE
make json_rpc type u64 to be consistent with other libs

### DIFF
--- a/src/server/request.rs
+++ b/src/server/request.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 /// to the one of the Ethereum RPC: https://ethereum.org/en/developers/docs/apis/json-rpc/#curl-examples
 #[derive(Serialize, Deserialize, Debug)]
 pub struct JSONRPCRequest {
-    pub id: u16,
+    pub id: u64,
     pub jsonrpc: String,
     pub method: String,
     pub params: Value,

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -10,13 +10,13 @@ const INVALID_REQUEST_CODE: i32 = -32600;
 /// the spec: https://www.jsonrpc.org/specification#response_object
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JSONRPCResultResponse<T> {
-    pub id: u16,
+    pub id: u64,
     pub jsonrpc: String,
     pub result: T,
 }
 
 impl<T: Serialize> JSONRPCResultResponse<T> {
-    pub fn new(id: u16, result: T) -> Self {
+    pub fn new(id: u64, result: T) -> Self {
         Self {
             id,
             jsonrpc: String::from(JSON_RPC_VERSION),
@@ -36,13 +36,13 @@ pub struct JSONRPCError<T> {
 /// The json rpc error response. It is the standard form our json-rpc and follows the spec: https://www.jsonrpc.org/specification#response_object
 #[derive(Debug, Serialize, Deserialize)]
 pub struct JSONRPCErrorResponse<T> {
-    pub id: u16,
+    pub id: u64,
     pub jsonrpc: String,
     pub error: JSONRPCError<T>,
 }
 
 impl JSONRPCErrorResponse<()> {
-    pub fn invalid_request(id: u16) -> Self {
+    pub fn invalid_request(id: u64) -> Self {
         Self {
             id,
             jsonrpc: String::from(JSON_RPC_VERSION),
@@ -55,7 +55,7 @@ impl JSONRPCErrorResponse<()> {
     }
 }
 impl<T: Serialize> JSONRPCErrorResponse<T> {
-    pub fn new(id: u16, error: JSONRPCError<T>) -> Self {
+    pub fn new(id: u64, error: JSONRPCError<T>) -> Self {
         Self {
             id,
             jsonrpc: String::from(JSON_RPC_VERSION),


### PR DESCRIPTION
Fix the type of ID in our json_rpc requests and reponses to `u64` so it is consistent with other external libraries