### PR TITLE
add timeout to improve cli ux

### DIFF
--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 use anyhow::{anyhow, Result};
@@ -23,6 +25,7 @@ mod tests;
 
 const DEFAULT_JSON_RPC_VERSION: &str = "2.0";
 const DEFAULT_JSON_RPC_ID: u8 = 1;
+const DEFAULT_REQ_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// A convenience constant that represents empty params in a JSON-RPC request.
 pub const NO_PARAMS: Value = json!([]);
@@ -64,6 +67,7 @@ impl JsonRpcClient for JsonRpcClientImpl {
     async fn request<T: DeserializeOwned>(&self, method: &str, params: Value) -> Result<T> {
         let request_body = build_jsonrpc_request(method, params)?;
         let mut builder = self.http_client.post(self.url.as_str()).json(&request_body);
+        builder = builder.timeout(DEFAULT_REQ_TIMEOUT);
 
         // Add the authorization bearer token if present
         if self.bearer_token.is_some() {

--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -25,7 +25,7 @@ mod tests;
 
 const DEFAULT_JSON_RPC_VERSION: &str = "2.0";
 const DEFAULT_JSON_RPC_ID: u8 = 1;
-const DEFAULT_REQ_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_REQ_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// A convenience constant that represents empty params in a JSON-RPC request.
 pub const NO_PARAMS: Value = json!([]);


### PR DESCRIPTION
While testing I realized that if a subnet is not mining the cli requests from the agent gets stuck forever without any feedback to the user. This PR includes a default timeout to all json-rpc requests from the lotus client. We could make this configurable but I don't think there is a use case right now.

NOTE: When a message is published to the mempool a peer will try to republish it periodically until it is accepted unless we tell it otherwise, which means that even if we timeout a request those that involve message could still go through. This is something worth documenting so users are aware. 