### PR TITLE
Send Value between addresses of the same subnet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1493,7 +1493,7 @@ checksum = "93ace6ec7cc19c8ed33a32eaa9ea692d7faea05006b5356b9e2b668ec4bc3955"
 [[package]]
 name = "fil_actors_runtime"
 version = "0.0.1"
-source = "git+https://github.com/consensus-shipyard/fvm-utils#9f8f945629dbe8d4dfd9084701f38eb30bb8bcc2"
+source = "git+https://github.com/consensus-shipyard/fvm-utils#4b837189a5e3009280001ecfeb18fae4ec3c599e"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -4145,7 +4145,7 @@ dependencies = [
 [[package]]
 name = "primitives"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/fvm-utils#9f8f945629dbe8d4dfd9084701f38eb30bb8bcc2"
+source = "git+https://github.com/consensus-shipyard/fvm-utils#4b837189a5e3009280001ecfeb18fae4ec3c599e"
 dependencies = [
  "anyhow",
  "cid",

--- a/src/cli/commands/manager/mod.rs
+++ b/src/cli/commands/manager/mod.rs
@@ -8,4 +8,5 @@ pub mod leave;
 pub mod list_subnets;
 pub mod propagate;
 pub mod release;
+pub mod send_value;
 pub mod whitelist;

--- a/src/cli/commands/manager/send_value.rs
+++ b/src/cli/commands/manager/send_value.rs
@@ -1,0 +1,59 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
+//! SendValue cli handler
+
+use async_trait::async_trait;
+use clap::Args;
+use std::fmt::Debug;
+
+use crate::cli::commands::get_ipc_agent_url;
+use crate::cli::{CommandLineHandler, GlobalArguments};
+use crate::config::json_rpc_methods;
+use crate::jsonrpc::{JsonRpcClient, JsonRpcClientImpl};
+use crate::server::send_value::SendValueParams;
+
+pub(crate) struct SendValue;
+
+#[async_trait]
+impl CommandLineHandler for SendValue {
+    type Arguments = SendValueArgs;
+
+    async fn handle(global: &GlobalArguments, arguments: &Self::Arguments) -> anyhow::Result<()> {
+        log::debug!("send value in subnet with args: {:?}", arguments);
+
+        let url = get_ipc_agent_url(&arguments.ipc_agent_url, global)?;
+        let json_rpc_client = JsonRpcClientImpl::new(url, None);
+
+        // The json rpc server will handle directing the request to
+        // the correct parent.
+        let params = SendValueParams {
+            subnet: arguments.subnet.clone(),
+            from: arguments.from.clone(),
+            to: arguments.to.clone(),
+            amount: arguments.amount,
+        };
+
+        json_rpc_client
+            .request::<()>(json_rpc_methods::SEND_VALUE, serde_json::to_value(params)?)
+            .await?;
+
+        log::info!("sending value in subnet: {:}", arguments.subnet);
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Args)]
+#[command(about = "Send value to an address within a subnet")]
+pub(crate) struct SendValueArgs {
+    #[arg(long, short, help = "The JSON RPC server url for ipc agent")]
+    pub ipc_agent_url: Option<String>,
+    #[arg(long, short, help = "The address to send value from")]
+    pub from: Option<String>,
+    #[arg(long, short, help = "The address to send value to")]
+    pub to: String,
+    #[arg(long, short, help = "The subnet of the addresses")]
+    pub subnet: String,
+    #[arg(help = "The amount to send (in whole FIL units)")]
+    pub amount: u64,
+}

--- a/src/cli/commands/mod.rs
+++ b/src/cli/commands/mod.rs
@@ -23,6 +23,8 @@ use clap::{Parser, Subcommand};
 use std::fmt::Debug;
 use url::Url;
 
+use self::manager::send_value::{SendValue, SendValueArgs};
+
 /// The collection of all subcommands to be called, see clap's documentation for usage. Internal
 /// to the current mode. Register a new command accordingly.
 #[derive(Debug, Subcommand)]
@@ -48,6 +50,7 @@ enum Commands {
     Release(ReleaseArgs),
     Propagate(PropagateArgs),
     WhitelistPropagator(WhitelistPropagatorArgs),
+    SendValue(SendValueArgs),
 }
 
 /// The overall command line struct to be used by `clap`.
@@ -113,6 +116,7 @@ pub async fn cli() {
         Commands::Release(args) => Release::handle(global, args).await,
         Commands::Propagate(args) => Propagate::handle(global, args).await,
         Commands::WhitelistPropagator(args) => WhitelistPropagator::handle(global, args).await,
+        Commands::SendValue(args) => SendValue::handle(global, args).await,
     };
 
     if let Err(e) = r {

--- a/src/config/server.rs
+++ b/src/config/server.rs
@@ -22,4 +22,5 @@ pub mod json_rpc_methods {
     pub const LIST_CHILD_SUBNETS: &str = "ipc_listChildSubnets";
     pub const RELOAD_CONFIG: &str = "ipc_reloadConfig";
     pub const QUERY_VALIDATOR_SET: &str = "ipc_queryValidatorSet";
+    pub const SEND_VALUE: &str = "ipc_sendValue";
 }

--- a/src/lotus/message/state.rs
+++ b/src/lotus/message/state.rs
@@ -46,7 +46,7 @@ pub struct Receipt {
 
 impl Receipt {
     pub fn parse_result_into<T: Default + DeserializeOwned>(self) -> anyhow::Result<T> {
-        if self.result == None {
+        if self.result.is_none() {
             return Ok(Default::default());
         }
 

--- a/src/lotus/message/state.rs
+++ b/src/lotus/message/state.rs
@@ -39,15 +39,19 @@ pub struct Receipt {
     #[allow(dead_code)]
     exit_code: u32,
     #[serde(rename = "Return")]
-    pub result: String,
+    pub result: Option<String>,
     #[allow(dead_code)]
     gas_used: u64,
 }
 
 impl Receipt {
-    pub fn parse_result_into<T: DeserializeOwned>(self) -> anyhow::Result<T> {
+    pub fn parse_result_into<T: Default + DeserializeOwned>(self) -> anyhow::Result<T> {
+        if self.result == None {
+            return Ok(Default::default());
+        }
+
         let r = base64::engine::general_purpose::STANDARD
-            .decode(self.result)
+            .decode(self.result.unwrap())
             .map_err(|e| {
                 log::error!("cannot base64 decode due to {e:?}");
                 anyhow!("cannot decode return string")

--- a/src/manager/lotus.rs
+++ b/src/manager/lotus.rs
@@ -8,6 +8,7 @@ use async_trait::async_trait;
 use cid::Cid;
 use fil_actors_runtime::types::{InitExecParams, InitExecReturn, INIT_EXEC_METHOD_NUM};
 use fil_actors_runtime::{builtin::singletons::INIT_ACTOR_ADDR, cbor};
+use fvm_shared::METHOD_SEND;
 use fvm_shared::{address::Address, econ::TokenAmount, MethodNum};
 use ipc_gateway::{Checkpoint, PropagateParams, WhitelistPropagatorParams};
 use ipc_sdk::subnet_id::SubnetID;
@@ -238,6 +239,16 @@ impl<T: JsonRpcClient + Send + Sync> SubnetManager for LotusSubnetManager<T> {
         );
 
         self.mpool_push_and_wait(message).await?;
+        Ok(())
+    }
+
+    /// Send value between two addresses in a subnet
+    async fn send_value(&self, from: Address, to: Address, amount: TokenAmount) -> Result<()> {
+        let mut message = MpoolPushMessage::new(to, from, METHOD_SEND, Vec::new());
+        message.value = amount;
+        self.mpool_push_and_wait(message).await?;
+        log::info!("sending FIL from {from:} to {to:}");
+
         Ok(())
     }
 }

--- a/src/manager/subnet.rs
+++ b/src/manager/subnet.rs
@@ -60,12 +60,7 @@ pub trait SubnetManager {
     async fn release(&self, subnet: SubnetID, from: Address, amount: TokenAmount) -> Result<()>;
 
     /// Propagate a cross-net message forward
-    async fn propagate(
-        &self,
-        subnet: SubnetID,
-        from: Address,
-        postbox_msg_cid: Cid,
-    ) -> anyhow::Result<()>;
+    async fn propagate(&self, subnet: SubnetID, from: Address, postbox_msg_cid: Cid) -> Result<()>;
 
     /// Whitelist a series of addresses as propagator of a cross net message
     async fn whitelist_propagator(
@@ -74,5 +69,8 @@ pub trait SubnetManager {
         postbox_msg_cid: Cid,
         from: Address,
         to_add: Vec<Address>,
-    ) -> anyhow::Result<()>;
+    ) -> Result<()>;
+
+    /// Send value between two addresses in a subnet
+    async fn send_value(&self, from: Address, to: Address, amount: TokenAmount) -> Result<()>;
 }

--- a/src/server/handlers/manager/mod.rs
+++ b/src/server/handlers/manager/mod.rs
@@ -8,6 +8,7 @@ pub mod leave;
 pub mod list_subnets;
 pub mod propagate;
 pub mod release;
+pub mod send_value;
 pub mod subnet;
 pub mod whitelist;
 

--- a/src/server/handlers/manager/send_value.rs
+++ b/src/server/handlers/manager/send_value.rs
@@ -1,0 +1,58 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
+//! SendValue subnet handler and parameters
+
+use crate::manager::SubnetManager;
+use crate::server::handlers::manager::subnet::SubnetManagerPool;
+use crate::server::handlers::manager::{check_subnet, parse_from};
+use crate::server::JsonRPCRequestHandler;
+use anyhow::anyhow;
+use async_trait::async_trait;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+use std::sync::Arc;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SendValueParams {
+    pub subnet: String,
+    pub from: Option<String>,
+    pub to: String,
+    pub amount: u64,
+}
+
+/// Send value between two addresses within a subnet
+pub(crate) struct SendValueHandler {
+    pool: Arc<SubnetManagerPool>,
+}
+
+impl SendValueHandler {
+    pub(crate) fn new(pool: Arc<SubnetManagerPool>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl JsonRPCRequestHandler for SendValueHandler {
+    type Request = SendValueParams;
+    type Response = ();
+
+    async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
+        let conn = match self.pool.get(&request.subnet) {
+            None => return Err(anyhow!("target parent subnet not found")),
+            Some(conn) => conn,
+        };
+
+        let amount = TokenAmount::from_whole(request.amount); // In FIL, not atto
+
+        let subnet_config = conn.subnet();
+        check_subnet(subnet_config)?;
+
+        let from = parse_from(subnet_config, request.from)?;
+        let to = Address::from_str(&request.to)?;
+
+        conn.manager().send_value(from, to, amount).await?;
+        Ok(())
+    }
+}

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -14,6 +14,7 @@ use crate::server::handlers::manager::list_subnets::ListSubnetsHandler;
 use crate::server::handlers::manager::propagate::PropagateHandler;
 use crate::server::handlers::manager::release::ReleaseHandler;
 use crate::server::handlers::manager::whitelist::WhitelistPropagatorHandler;
+use crate::server::handlers::send_value::SendValueHandler;
 use crate::server::handlers::validator::QueryValidatorSetHandler;
 use crate::server::JsonRPCRequestHandler;
 use anyhow::{anyhow, Result};
@@ -92,6 +93,9 @@ impl Handlers {
 
         let h: Box<dyn HandlerWrapper> = Box::new(WhitelistPropagatorHandler::new(pool.clone()));
         handlers.insert(String::from(json_rpc_methods::WHITELIST_PROPAGATOR), h);
+
+        let h: Box<dyn HandlerWrapper> = Box::new(SendValueHandler::new(pool.clone()));
+        handlers.insert(String::from(json_rpc_methods::SEND_VALUE), h);
 
         let h: Box<dyn HandlerWrapper> = Box::new(ListSubnetsHandler::new(pool));
         handlers.insert(String::from(json_rpc_methods::LIST_CHILD_SUBNETS), h);


### PR DESCRIPTION
The same way that we provide methods to send value between addresses in different subnets, it is useful to provide a way through the agent to send tokens between addresses in the same subnet. When testing the agent, I realized this is a common operation, and after having configured the agent to operate with a specific subnet peer, is kind of an overhead to have to connect to the Lotus API of the corresponding peer, send the request, etc. This is even worse when the peer is run in docker. 

This PR:
- Includes a new method `send-value` that allows to send value between two addresses in the same subnet.
- Fixes a bug for which `state_wait_msg` failed when the return value is empty.  