### PR TITLE
Add context to error propagation in manage_subnet

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
+#![feature(try_blocks)]
 pub mod cli;
 pub mod config;
 pub mod jsonrpc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
+#![feature(try_blocks)]
 use fvm_shared::address::{set_current_network, Network};
 use ipc_agent::cli;
 use num_traits::FromPrimitive;


### PR DESCRIPTION
Wraps the bulk of the checkpoint logic in a `try` block and adds error context to the result of the block.