### PR TITLE
Include gateway addr in subnet config

### DIFF
--- a/config/template.toml
+++ b/config/template.toml
@@ -3,14 +3,18 @@ json_rpc_address = "127.0.0.1:3030"
 
 [subnets]
 
-[subnets.root]
+[[subnets]]
 id = "/root"
+network_name = "root"
+gateway_addr = 64
 jsonrpc_api_http = "https://example.org/rpc/v0"
 jsonrpc_api_ws = "wss://example.org/rpc/v0"
 auth_token = "YOUR ROOT AUTH TOKEN"
 
-[subnets.child]
+[[subnets]]
 id = "/root/t0100"
+network_name = "child"
+gateway_addr = 64
 jsonrpc_api_http = "https://example.org/rpc/v2"
 auth_token = "YOUR CHILD AUTH TOKEN"
 accounts = ["t3thgjtvoi65yzdcoifgqh6utjbaod3ukidxrx34heu34d6avx6z7r5766t5jqt42a44ehzcnw3u5ehz47n42a"]

--- a/src/config/deserialize.rs
+++ b/src/config/deserialize.rs
@@ -2,12 +2,56 @@
 // SPDX-License-Identifier: MIT
 //! Deserialization utils for config mod.
 
+use crate::config::Subnet;
 use fvm_shared::address::Address;
 use ipc_sdk::subnet_id::SubnetID;
 use serde::de::{Error, SeqAccess};
-use serde::Deserializer;
+use serde::{Deserialize, Deserializer};
+use std::collections::HashMap;
 use std::fmt::Formatter;
 use std::str::FromStr;
+
+/// A serde deserialization method to deserialize a hashmap of subnets with subnet id as key and
+/// Subnet struct as value from a vec of subnets
+pub(crate) fn deserialize_subnets_from_vec<'de, D>(
+    deserializer: D,
+) -> anyhow::Result<HashMap<SubnetID, Subnet>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let subnets = <Vec<Subnet>>::deserialize(deserializer)?;
+
+    let mut hashmap = HashMap::new();
+    for subnet in subnets {
+        hashmap.insert(subnet.id.clone(), subnet);
+    }
+    Ok(hashmap)
+}
+
+/// A serde deserialization method to deserialize an address from i64
+pub(crate) fn deserialize_address_from_i64<'de, D>(
+    deserializer: D,
+) -> anyhow::Result<Address, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct Visitor;
+    impl<'de> serde::de::Visitor<'de> for Visitor {
+        type Value = Address;
+
+        fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+            formatter.write_str("an u64")
+        }
+
+        fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+        where
+            E: Error,
+        {
+            Ok(Address::new_id(v as u64))
+        }
+    }
+    deserializer.deserialize_i64(Visitor)
+}
 
 /// A serde deserialization method to deserialize a subnet path string into a [`SubnetID`].
 pub(crate) fn deserialize_subnet_id<'de, D>(deserializer: D) -> anyhow::Result<SubnetID, D::Error>

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,6 +18,8 @@ use std::fs;
 use std::path::Path;
 
 use anyhow::Result;
+use ipc_sdk::subnet_id::SubnetID;
+use deserialize::deserialize_subnets_from_vec;
 pub use reload::ReloadableConfig;
 use serde::Deserialize;
 pub use server::JSON_RPC_ENDPOINT;
@@ -32,17 +34,19 @@ pub const DEFAULT_CONFIG_TEMPLATE: &str = r#"
 [server]
 json_rpc_address = "127.0.0.1:3030"
 
-[subnets]
-
-[subnets."/root"]
+[[subnets]]
 id = "/root"
+gateway_addr = 64
+network_name = "root"
 jsonrpc_api_http = "http://127.0.0.1:1235/rpc/v1"
 jsonrpc_api_ws = "wss://example.org/rpc/v0"
 auth_token = "YOUR TOKEN"
 accounts = ["t01"]
 
-[subnets."/root/t01"]
+[[subnets]]
 id = "/root/t01"
+gateway_addr = 64
+network_name = "child"
 jsonrpc_api_http = "http://127.0.0.1:1235/rpc/v1"
 auth_token = "YOUR TOKEN"
 accounts = ["t01"]
@@ -53,7 +57,8 @@ accounts = ["t01"]
 #[derive(Deserialize, Debug)]
 pub struct Config {
     pub server: Server,
-    pub subnets: HashMap<String, Subnet>,
+    #[serde(deserialize_with = "deserialize_subnets_from_vec")]
+    pub subnets: HashMap<SubnetID, Subnet>,
 }
 
 impl Config {

--- a/src/config/subnet.rs
+++ b/src/config/subnet.rs
@@ -5,13 +5,19 @@ use ipc_sdk::subnet_id::SubnetID;
 use serde::Deserialize;
 use url::Url;
 
-use crate::config::deserialize::{deserialize_accounts, deserialize_subnet_id};
+use crate::config::deserialize::{
+    deserialize_accounts, deserialize_address_from_i64, deserialize_subnet_id
+};
 
 /// Represents a subnet declaration in the config.
 #[derive(Deserialize, Clone, Debug)]
 pub struct Subnet {
     #[serde(deserialize_with = "deserialize_subnet_id")]
     pub id: SubnetID,
+    #[serde(deserialize_with = "deserialize_address_from_i64")]
+    // toml is interpreting number as i64
+    pub gateway_addr: Address,
+    pub network_name: String,
     pub jsonrpc_api_http: Url,
     pub jsonrpc_api_ws: Option<Url>,
     pub auth_token: Option<String>,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -17,6 +17,7 @@ use crate::config::{Config, ReloadableConfig};
 const SERVER_JSON_RPC_ADDR: &str = "127.0.0.1:3030";
 const ROOT_ID: &str = "/root";
 const CHILD_ID: &str = "/root/t0100";
+const GATEWAY_ADDR: u64 = 64;
 const ROOT_AUTH_TOKEN: &str = "ROOT_AUTH_TOKEN";
 const CHILD_AUTH_TOKEN: &str = "CHILD_AUTH_TOKEN";
 const JSONRPC_API_HTTP: &str = "https://example.org/rpc/v0";
@@ -96,8 +97,10 @@ fn check_server_config() {
 fn check_subnets_config() {
     let config = read_config().subnets;
 
-    let root = &config["root"];
+    let root = &config[&ROOTNET_ID];
     assert_eq!(root.id, *ROOTNET_ID);
+    assert_eq!(root.network_name, "root");
+    assert_eq!(root.gateway_addr, Address::new_id(GATEWAY_ADDR));
     assert_eq!(
         root.jsonrpc_api_http,
         Url::from_str(JSONRPC_API_HTTP).unwrap()
@@ -108,8 +111,11 @@ fn check_subnets_config() {
     );
     assert_eq!(root.auth_token.as_ref().unwrap(), ROOT_AUTH_TOKEN);
 
-    let child = &config["child"];
-    assert_eq!(child.id, SubnetID::from_str(CHILD_ID).unwrap(),);
+    let child_id = SubnetID::from_str(CHILD_ID).unwrap();
+    let child = &config[&child_id];
+    assert_eq!(child.id, child_id);
+    assert_eq!(child.network_name, "child");
+    assert_eq!(child.gateway_addr, Address::new_id(GATEWAY_ADDR));
     assert_eq!(
         child.jsonrpc_api_http,
         Url::from_str(JSONRPC_API_HTTP).unwrap(),
@@ -127,14 +133,18 @@ fn config_str() -> String {
             [server]
             json_rpc_address = "{SERVER_JSON_RPC_ADDR}"
 
-            [subnets]
-            [subnets.root]
+            [[subnets]]
             id = "{ROOT_ID}"
+            gateway_addr = {GATEWAY_ADDR}
+            network_name = "root"
             jsonrpc_api_http = "{JSONRPC_API_HTTP}"
             jsonrpc_api_ws = "{JSONRPC_API_WS}"
             auth_token = "{ROOT_AUTH_TOKEN}"
-            [subnets.child]
+
+            [[subnets]]
             id = "{CHILD_ID}"
+            network_name = "child"
+            gateway_addr = {GATEWAY_ADDR}
             jsonrpc_api_http = "{JSONRPC_API_HTTP}"
             auth_token = "{CHILD_AUTH_TOKEN}"
             accounts = ["{ACCOUNT_ADDRESS}"]
@@ -148,14 +158,18 @@ fn config_str_diff_addr() -> String {
             [server]
             json_rpc_address = "127.0.0.1:3031"
 
-            [subnets]
-            [subnets.root]
+            [[subnets]]
             id = "{ROOT_ID}"
+            network_name = "root"
+            gateway_addr = {GATEWAY_ADDR}
             jsonrpc_api_http = "{JSONRPC_API_HTTP}"
             jsonrpc_api_ws = "{JSONRPC_API_WS}"
             auth_token = "{ROOT_AUTH_TOKEN}"
-            [subnets.child]
+
+            [[subnets]]
             id = "{CHILD_ID}"
+            network_name = "child"
+            gateway_addr = {GATEWAY_ADDR}
             jsonrpc_api_http = "{JSONRPC_API_HTTP}"
             auth_token = "{CHILD_AUTH_TOKEN}"
             accounts = ["{ACCOUNT_ADDRESS}"]
@@ -169,16 +183,18 @@ fn read_config() -> Config {
             [server]
             json_rpc_address = "{SERVER_JSON_RPC_ADDR}"
 
-            [subnets]
-
-            [subnets.root]
+            [[subnets]]
             id = "{ROOT_ID}"
+            network_name = "root"
+            gateway_addr = {GATEWAY_ADDR}
             jsonrpc_api_http = "{JSONRPC_API_HTTP}"
             jsonrpc_api_ws = "{JSONRPC_API_WS}"
             auth_token = "{ROOT_AUTH_TOKEN}"
 
-            [subnets.child]
+            [[subnets]]
             id = "{CHILD_ID}"
+            network_name = "child"
+            gateway_addr = {GATEWAY_ADDR}
             jsonrpc_api_http = "{JSONRPC_API_HTTP}"
             auth_token = "{CHILD_AUTH_TOKEN}"
             accounts = ["{ACCOUNT_ADDRESS}"]

--- a/src/manager/checkpoint.rs
+++ b/src/manager/checkpoint.rs
@@ -123,13 +123,7 @@ impl IntoSubsystem<anyhow::Error> for CheckpointSubsystem {
 /// manage checkpoint for. This means that for each `child_subnet` there exists at least one account
 /// for which we need to submit checkpoints on behalf of to `parent_subnet`, which must also be
 /// present in the map.
-fn subnets_to_manage(subnets: &HashMap<String, Subnet>) -> Vec<(Subnet, Subnet)> {
-    // First, we remap subnets by SubnetID.
-    let subnets_by_id: HashMap<SubnetID, Subnet> = subnets
-        .values()
-        .map(|s| (s.id.clone(), s.clone()))
-        .collect();
-
+fn subnets_to_manage(subnets_by_id: &HashMap<SubnetID, Subnet>) -> Vec<(Subnet, Subnet)> {
     // Then, we filter for subnets that have at least one account and for which the parent subnet
     // is also in the map, and map into a Vec of (child_subnet, parent_subnet) tuples.
     subnets_by_id

--- a/src/server/handlers/manager/create.rs
+++ b/src/server/handlers/manager/create.rs
@@ -51,15 +51,14 @@ impl JsonRPCRequestHandler for CreateSubnetHandler {
     type Response = CreateSubnetResponse;
 
     async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
-        let parent = &request.parent;
-
-        let conn = match self.pool.get(parent) {
+        let parent = SubnetID::from_str(&request.parent)?;
+        let conn = match self.pool.get(&parent) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,
         };
 
         let constructor_params = ConstructParams {
-            parent: SubnetID::from_str(parent)?,
+            parent,
             name: request.name,
             ipc_gateway_addr: DEFAULT_IPC_GATEWAY_ADDR,
             consensus: ConsensusType::Mir,

--- a/src/server/handlers/manager/fund.rs
+++ b/src/server/handlers/manager/fund.rs
@@ -40,8 +40,7 @@ impl JsonRPCRequestHandler for FundHandler {
         let subnet = SubnetID::from_str(&request.subnet)?;
         let parent = subnet
             .parent()
-            .ok_or_else(|| anyhow!("no parent found"))?
-            .to_string();
+            .ok_or_else(|| anyhow!("no parent found"))?;
         let conn = match self.pool.get(&parent) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,

--- a/src/server/handlers/manager/join.rs
+++ b/src/server/handlers/manager/join.rs
@@ -43,8 +43,7 @@ impl JsonRPCRequestHandler for JoinSubnetHandler {
         let subnet = SubnetID::from_str(&request.subnet)?;
         let parent = subnet
             .parent()
-            .ok_or_else(|| anyhow!("no parent found"))?
-            .to_string();
+            .ok_or_else(|| anyhow!("no parent found"))?;
         let conn = match self.pool.get(&parent) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,

--- a/src/server/handlers/manager/kill.rs
+++ b/src/server/handlers/manager/kill.rs
@@ -39,9 +39,7 @@ impl JsonRPCRequestHandler for KillSubnetHandler {
         let subnet = SubnetID::from_str(&request.subnet)?;
         let parent = subnet
             .parent()
-            .ok_or_else(|| anyhow!("no parent found"))?
-            .to_string();
-
+            .ok_or_else(|| anyhow!("no parent found"))?;
         let conn = match self.pool.get(&parent) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,

--- a/src/server/handlers/manager/leave.rs
+++ b/src/server/handlers/manager/leave.rs
@@ -39,9 +39,7 @@ impl JsonRPCRequestHandler for LeaveSubnetHandler {
         let subnet = SubnetID::from_str(&request.subnet)?;
         let parent = subnet
             .parent()
-            .ok_or_else(|| anyhow!("no parent found"))?
-            .to_string();
-
+            .ok_or_else(|| anyhow!("no parent found"))?;
         let conn = match self.pool.get(&parent) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,

--- a/src/server/handlers/manager/list_subnets.rs
+++ b/src/server/handlers/manager/list_subnets.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
+use ipc_sdk::subnet_id::SubnetID;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ListSubnetsParams {
@@ -38,7 +39,8 @@ impl JsonRPCRequestHandler for ListSubnetsHandler {
     type Response = HashMap<String, SubnetInfo>;
 
     async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
-        let conn = match self.pool.get(&request.subnet_id) {
+        let subnet = SubnetID::from_str(&request.subnet_id)?;
+        let conn = match self.pool.get(&subnet) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,
         };

--- a/src/server/handlers/manager/propagate.rs
+++ b/src/server/handlers/manager/propagate.rs
@@ -37,7 +37,8 @@ impl JsonRPCRequestHandler for PropagateHandler {
     type Response = ();
 
     async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
-        let conn = match self.pool.get(&request.subnet) {
+        let subnet = SubnetID::from_str(&request.subnet)?;
+        let conn = match self.pool.get(&subnet) {
             None => return Err(anyhow!("target subnet not found")),
             Some(conn) => conn,
         };

--- a/src/server/handlers/manager/release.rs
+++ b/src/server/handlers/manager/release.rs
@@ -37,7 +37,8 @@ impl JsonRPCRequestHandler for ReleaseHandler {
     type Response = ();
 
     async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
-        let conn = match self.pool.get(&request.subnet) {
+        let subnet = SubnetID::from_str(&request.subnet)?;
+        let conn = match self.pool.get(&subnet) {
             None => return Err(anyhow!("target subnet not found")),
             Some(conn) => conn,
         };
@@ -45,9 +46,7 @@ impl JsonRPCRequestHandler for ReleaseHandler {
         let subnet_config = conn.subnet();
         check_subnet(subnet_config)?;
 
-        let subnet = SubnetID::from_str(&request.subnet)?;
         let amount = TokenAmount::from_whole(request.amount);
-
         let from = parse_from(subnet_config, request.from)?;
 
         conn.manager().release(subnet, from, amount).await

--- a/src/server/handlers/manager/send_value.rs
+++ b/src/server/handlers/manager/send_value.rs
@@ -13,6 +13,7 @@ use fvm_shared::econ::TokenAmount;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::sync::Arc;
+use ipc_sdk::subnet_id::SubnetID;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SendValueParams {
@@ -39,7 +40,8 @@ impl JsonRPCRequestHandler for SendValueHandler {
     type Response = ();
 
     async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
-        let conn = match self.pool.get(&request.subnet) {
+        let subnet = SubnetID::from_str(&request.subnet)?;
+        let conn = match self.pool.get(&subnet) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(conn) => conn,
         };

--- a/src/server/handlers/manager/subnet.rs
+++ b/src/server/handlers/manager/subnet.rs
@@ -6,6 +6,7 @@ use crate::config::{ReloadableConfig, Subnet};
 use crate::jsonrpc::{JsonRpcClient, JsonRpcClientImpl};
 use crate::manager::LotusSubnetManager;
 use std::sync::Arc;
+use ipc_sdk::subnet_id::SubnetID;
 
 /// The subnet manager connection that holds the subnet config and the manager instance.
 pub struct Connection<T: JsonRpcClient> {
@@ -37,11 +38,11 @@ impl SubnetManagerPool {
     }
 
     /// Get the connection instance for the subnet.
-    pub fn get(&self, subnet_str: &str) -> Option<Connection<JsonRpcClientImpl>> {
+    pub fn get(&self, subnet: &SubnetID) -> Option<Connection<JsonRpcClientImpl>> {
         let config = self.config.get_config();
         let subnets = &config.subnets;
 
-        match subnets.get(subnet_str) {
+        match subnets.get(subnet) {
             Some(subnet) => {
                 let manager = LotusSubnetManager::from_subnet(subnet);
                 Some(Connection {

--- a/src/server/handlers/manager/wallet.rs
+++ b/src/server/handlers/manager/wallet.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use std::sync::Arc;
+use ipc_sdk::subnet_id::SubnetID;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WalletNewParams {
@@ -40,7 +41,8 @@ impl JsonRPCRequestHandler for WalletNewHandler {
     type Response = WalletNewResponse;
 
     async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
-        let conn = match self.pool.get(&request.subnet) {
+        let subnet = SubnetID::from_str(&request.subnet)?;
+        let conn = match self.pool.get(&subnet) {
             None => return Err(anyhow!("target subnet not found")),
             Some(conn) => conn,
         };

--- a/src/server/handlers/manager/whitelist.rs
+++ b/src/server/handlers/manager/whitelist.rs
@@ -39,7 +39,8 @@ impl JsonRPCRequestHandler for WhitelistPropagatorHandler {
     type Response = ();
 
     async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
-        let conn = match self.pool.get(&request.subnet) {
+        let subnet = SubnetID::from_str(&request.subnet)?;
+        let conn = match self.pool.get(&subnet) {
             None => return Err(anyhow!("target subnet not found")),
             Some(conn) => conn,
         };
@@ -47,7 +48,6 @@ impl JsonRPCRequestHandler for WhitelistPropagatorHandler {
         let subnet_config = conn.subnet();
         check_subnet(subnet_config)?;
 
-        let subnet = SubnetID::from_str(&request.subnet)?;
         let to_add = request
             .to_add
             .iter()

--- a/src/server/handlers/validator.rs
+++ b/src/server/handlers/validator.rs
@@ -46,11 +46,9 @@ impl JsonRPCRequestHandler for QueryValidatorSetHandler {
         let subnet_id = SubnetID::from_str(&request.subnet)?;
         let parent = subnet_id
             .parent()
-            .ok_or_else(|| anyhow!("cannot get for root"))?
-            .to_string();
+            .ok_or_else(|| anyhow!("cannot get for root"))?;
 
         let config = self.config.get_config();
-        // TODO: once get_by_subnet_id is merged, will use parent subnet id directly.
         let subnet = match config.subnets.get(&parent) {
             None => return Err(anyhow!("target parent subnet not found")),
             Some(s) => s,


### PR DESCRIPTION
The changes in this PR:
- Add gateway address and network name in subnet config. 
- Replace subnets from `Hashmap<String, Subnet>` to `Hashmap<SubnetID, Subnet>`, so that all the look ups we can directly use subnet id instead of converting to string.
- Updated subnets config from key value map style to array.