### PR TITLE
minimum validators in query validatorSet

### DIFF
--- a/src/lotus/message/ipc.rs
+++ b/src/lotus/message/ipc.rs
@@ -36,6 +36,7 @@ pub struct IPCReadGatewayStateResponse {
 pub struct IPCReadSubnetActorStateResponse {
     pub check_period: ChainEpoch,
     pub validator_set: ValidatorSet,
+    pub min_validators: u64,
 }
 
 /// SubnetInfo is an auxiliary struct that collects relevant information about the state of a subnet

--- a/src/server/handlers/validator.rs
+++ b/src/server/handlers/validator.rs
@@ -22,8 +22,10 @@ pub struct QueryValidatorSetParams {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct QueryValidatorSetResponse {
-    /// The address of the created subnet
+    /// The validator set for the subnet fetched from the parent.
     pub validator_set: ValidatorSet,
+    /// Minimum number of validators required by the subnet
+    pub min_validators: u64,
 }
 
 /// The create subnet json rpc method handler.
@@ -71,6 +73,7 @@ impl JsonRPCRequestHandler for QueryValidatorSetHandler {
 
         Ok(QueryValidatorSetResponse {
             validator_set: response.validator_set,
+            min_validators: response.min_validators,
         })
     }
 }


### PR DESCRIPTION
- Add a minimum validators in the validator set query so the Mir validator can use it to determine if it should start validating new blocks or it should fail until we have additional validators. 
- I also took the opportunity to introduce a slight change in the logging of the checkpoint manager. 