### PR TITLE
Adds ToJson trait to facilitate converstion of SubnetID to JSON

### DIFF
--- a/src/lotus/json.rs
+++ b/src/lotus/json.rs
@@ -1,0 +1,37 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
+
+use anyhow::anyhow;
+use ipc_sdk::subnet_id::SubnetID;
+use serde_json::{json, Value};
+
+/// A trait to convert a type to a JSON value.
+pub(crate) trait ToJson {
+    fn to_json(&self) -> Value;
+}
+
+/// Implement the `ToJson` trait for `SubnetID`.
+impl ToJson for SubnetID {
+    fn to_json(&self) -> Value {
+        let parent = self
+            .parent()
+            .ok_or_else(|| anyhow!("no parent found"))
+            .unwrap()
+            .to_string();
+        let actor = self.subnet_actor().to_string();
+        json!({"Parent": parent, "Actor": actor})
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_to_json() {
+    use std::str::FromStr;
+    let subnet_id = SubnetID::from_str("/root/t0102").unwrap();
+    let json = subnet_id.to_json();
+    assert_eq!(
+        json,
+        json!({"Parent": "/root", "Actor": "t0102"}),
+        "subnet id to json failed"
+    );
+}

--- a/src/lotus/mod.rs
+++ b/src/lotus/mod.rs
@@ -24,6 +24,7 @@ use crate::manager::SubnetInfo;
 use self::message::CIDMap;
 
 pub mod client;
+mod json;
 pub mod message;
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
This PR adds a `ToJson` trait and implements it for `SubnetID`. This reduces a substantial amount of boilerplate code in the `LotusClient` implementation. It's a dependency for #140 and #141.