### PR TITLE
use tag versioning for ipc-actors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 [[package]]
 name = "ipc-gateway"
 version = "0.0.1"
-source = "git+https://github.com/consensus-shipyard/ipc-actors.git#186a7cb1e6b1745d9013b4556a14e5ffc0c09929"
+source = "git+https://github.com/consensus-shipyard/ipc-actors.git?tag=v0.1.0#186a7cb1e6b1745d9013b4556a14e5ffc0c09929"
 dependencies = [
  "anyhow",
  "cid",
@@ -2499,7 +2499,7 @@ dependencies = [
 [[package]]
 name = "ipc-sdk"
 version = "0.0.1"
-source = "git+https://github.com/consensus-shipyard/ipc-actors.git#186a7cb1e6b1745d9013b4556a14e5ffc0c09929"
+source = "git+https://github.com/consensus-shipyard/ipc-actors.git?tag=v0.1.0#186a7cb1e6b1745d9013b4556a14e5ffc0c09929"
 dependencies = [
  "fil_actors_runtime",
  "fvm_ipld_encoding 0.3.3",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "ipc-subnet-actor"
 version = "0.0.1"
-source = "git+https://github.com/consensus-shipyard/ipc-actors.git#186a7cb1e6b1745d9013b4556a14e5ffc0c09929"
+source = "git+https://github.com/consensus-shipyard/ipc-actors.git?tag=v0.1.0#186a7cb1e6b1745d9013b4556a14e5ffc0c09929"
 dependencies = [
  "anyhow",
  "cid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,8 @@ fvm_ipld_blockstore = "0.1"
 fvm_ipld_encoding = "0.3"
 fvm_shared = { version = "=3.0.0-alpha.17", default-features = false }
 fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", features = ["fil-actor"] }
-ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-actors.git"}
-ipc-subnet-actor = { git = "https://github.com/consensus-shipyard/ipc-actors.git", features = []}
-ipc-gateway = { git = "https://github.com/consensus-shipyard/ipc-actors.git", features = []}
+ipc-sdk = { git = "https://github.com/consensus-shipyard/ipc-actors.git", tag = "v0.1.0"}
+ipc-subnet-actor = { git = "https://github.com/consensus-shipyard/ipc-actors.git", tag = "v0.1.0", features = []}
+ipc-gateway = { git = "https://github.com/consensus-shipyard/ipc-actors.git",tag = "v0.1.0", features = []}
 libipld = { version = "0.14", default-features = false, features = ["dag-cbor"] }
 primitives = { git = "https://github.com/consensus-shipyard/fvm-utils"}


### PR DESCRIPTION
As we are making changes to IPC actors, we may introduce changes that are not backward compatible for the agent. To clearly tag the version of actors an IPC agent is compatible with, this PR introduces tagged version to the IPC actors dependency. 

In the future, we should use proper versions through a published crate instead of pointing to a tag in a repo, but for now, as the code is not yet stable and we expect changes quite often, it is more comfortable to publish always the same cargo version `v0.0.1` and use `tag` to determine the github `release` of the actors a version of the agent is compatible with.