### PR TITLE
Update Checkpoint serialization/deserialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@ pub mod config;
 pub mod jsonrpc;
 pub mod lotus;
 pub mod manager;
+mod serialization;
 pub mod server;

--- a/src/lotus/mod.rs
+++ b/src/lotus/mod.rs
@@ -19,7 +19,7 @@ use message::state::{ReadStateResponse, StateWaitMsgResponse};
 use message::wallet::{WalletKeyType, WalletListResponse};
 
 use crate::lotus::message::ipc::{
-    BottomUpCheckpointWrapper, IPCReadGatewayStateResponse, IPCReadSubnetActorStateResponse, Votes,
+    IPCReadGatewayStateResponse, IPCReadSubnetActorStateResponse, Votes,
 };
 use crate::manager::SubnetInfo;
 
@@ -120,7 +120,7 @@ pub trait LotusClient: LotusBottomUpCheckpointClient {
         subnet_id: SubnetID,
         from_epoch: ChainEpoch,
         to_epoch: ChainEpoch,
-    ) -> Result<Vec<BottomUpCheckpointWrapper>>;
+    ) -> Result<Vec<BottomUpCheckpoint>>;
 }
 
 /// Bottom up checkpoint client for the gateway

--- a/src/manager/lotus.rs
+++ b/src/manager/lotus.rs
@@ -19,7 +19,7 @@ use ipc_subnet_actor::{types::MANIFEST_ID, ConstructParams, JoinParams};
 use crate::config::Subnet;
 use crate::jsonrpc::{JsonRpcClient, JsonRpcClientImpl};
 use crate::lotus::client::LotusJsonRPCClient;
-use crate::lotus::message::ipc::{BottomUpCheckpointWrapper, SubnetInfo};
+use crate::lotus::message::ipc::SubnetInfo;
 use crate::lotus::message::mpool::MpoolPushMessage;
 use crate::lotus::message::state::StateWaitMsgResponse;
 use crate::lotus::message::wallet::WalletKeyType;
@@ -482,7 +482,7 @@ impl<T: JsonRpcClient + Send + Sync> SubnetManager for LotusSubnetManager<T> {
         subnet_id: SubnetID,
         from_epoch: ChainEpoch,
         to_epoch: ChainEpoch,
-    ) -> Result<Vec<BottomUpCheckpointWrapper>> {
+    ) -> Result<Vec<BottomUpCheckpoint>> {
         let checkpoints = self
             .lotus_client
             .ipc_list_checkpoints(subnet_id, from_epoch, to_epoch)

--- a/src/manager/subnet.rs
+++ b/src/manager/subnet.rs
@@ -13,7 +13,6 @@ use ipc_gateway::BottomUpCheckpoint;
 use ipc_sdk::subnet_id::SubnetID;
 use ipc_subnet_actor::{ConstructParams, JoinParams};
 
-use crate::lotus::message::ipc::BottomUpCheckpointWrapper;
 use crate::lotus::message::{ipc::SubnetInfo, wallet::WalletKeyType};
 
 /// Trait to interact with a subnet and handle its lifecycle.
@@ -106,7 +105,7 @@ pub trait SubnetManager: BottomUpCheckpointManager {
         subnet_id: SubnetID,
         from_epoch: ChainEpoch,
         to_epoch: ChainEpoch,
-    ) -> Result<Vec<BottomUpCheckpointWrapper>>;
+    ) -> Result<Vec<BottomUpCheckpoint>>;
 }
 
 /// The bottom up checkpoint manager

--- a/src/serialization/checkpoint.rs
+++ b/src/serialization/checkpoint.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 //! Json serialization of checkpoints
 
-use crate::serialization::AsJson;
+use crate::serialization::SerializeToJson;
 use base64::Engine;
 use ipc_gateway::checkpoint::{BatchCrossMsgs, CheckData};
 use ipc_gateway::BottomUpCheckpoint;
@@ -10,14 +10,14 @@ use num_traits::ToPrimitive;
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
 
-impl Serialize for AsJson<BottomUpCheckpoint> {
+impl Serialize for SerializeToJson<BottomUpCheckpoint> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         let BottomUpCheckpoint { data, sig } = &self.0;
 
-        let data = AsJson(data);
+        let data = SerializeToJson(data);
         let sig = base64::engine::general_purpose::STANDARD.encode(sig);
 
         let mut state = serializer.serialize_struct("BottomUpCheckpoint", 2)?;
@@ -27,7 +27,7 @@ impl Serialize for AsJson<BottomUpCheckpoint> {
     }
 }
 
-impl<'a> Serialize for AsJson<&'a CheckData> {
+impl<'a> Serialize for SerializeToJson<&'a CheckData> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -59,7 +59,7 @@ impl<'a> Serialize for AsJson<&'a CheckData> {
                 })
             })
             .collect::<Vec<_>>();
-        let cross_msgs = AsJson(cross_msgs);
+        let cross_msgs = SerializeToJson(cross_msgs);
 
         let mut state = serializer.serialize_struct("CheckData", 6)?;
         state.serialize_field("source", &source)?;
@@ -73,7 +73,7 @@ impl<'a> Serialize for AsJson<&'a CheckData> {
     }
 }
 
-impl<'a> Serialize for AsJson<&'a BatchCrossMsgs> {
+impl<'a> Serialize for SerializeToJson<&'a BatchCrossMsgs> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
@@ -106,14 +106,14 @@ impl<'a> Serialize for AsJson<&'a BatchCrossMsgs> {
 
 #[cfg(test)]
 mod tests {
-    use crate::serialization::AsJson;
+    use crate::serialization::SerializeToJson;
     use ipc_gateway::BottomUpCheckpoint;
     use ipc_sdk::subnet_id::ROOTNET_ID;
 
     #[test]
     fn test_serialization() {
         let cp = BottomUpCheckpoint::new(ROOTNET_ID.clone(), 10);
-        let v = serde_json::to_string(&AsJson(cp)).unwrap();
+        let v = serde_json::to_string(&SerializeToJson(cp)).unwrap();
         println!("{v:}");
     }
 }

--- a/src/serialization/checkpoint.rs
+++ b/src/serialization/checkpoint.rs
@@ -1,3 +1,5 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
 //! Json serialization of checkpoints
 
 use crate::serialization::AsJson;

--- a/src/serialization/checkpoint.rs
+++ b/src/serialization/checkpoint.rs
@@ -1,0 +1,117 @@
+//! Json serialization of checkpoints
+
+use crate::serialization::AsJson;
+use base64::Engine;
+use ipc_gateway::checkpoint::{BatchCrossMsgs, CheckData};
+use ipc_gateway::BottomUpCheckpoint;
+use num_traits::ToPrimitive;
+use serde::ser::SerializeStruct;
+use serde::{Serialize, Serializer};
+
+impl Serialize for AsJson<BottomUpCheckpoint> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let BottomUpCheckpoint { data, sig } = &self.0;
+
+        let data = AsJson(data);
+        let sig = base64::engine::general_purpose::STANDARD.encode(sig);
+
+        let mut state = serializer.serialize_struct("BottomUpCheckpoint", 2)?;
+        state.serialize_field("data", &data)?;
+        state.serialize_field("sig", &sig)?;
+        state.end()
+    }
+}
+
+impl<'a> Serialize for AsJson<&'a CheckData> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let CheckData {
+            source,
+            proof,
+            epoch,
+            prev_check,
+            children,
+            cross_msgs,
+        } = self.0;
+
+        let source = source.to_string();
+        let proof = base64::engine::general_purpose::STANDARD.encode(proof);
+        let prev_check = prev_check.to_string();
+        let children = children
+            .iter()
+            .map(|c| {
+                let source = c.source.to_string();
+                let checks = c
+                    .checks
+                    .iter()
+                    .map(|cid| cid.to_string())
+                    .collect::<Vec<_>>();
+                serde_json::json!({
+                    "source": source,
+                    "checks": checks,
+                })
+            })
+            .collect::<Vec<_>>();
+        let cross_msgs = AsJson(cross_msgs);
+
+        let mut state = serializer.serialize_struct("CheckData", 6)?;
+        state.serialize_field("source", &source)?;
+        state.serialize_field("proof", &proof)?;
+        state.serialize_field("epoch", epoch)?;
+        state.serialize_field("prev_check", &prev_check)?;
+        state.serialize_field("children", &children)?;
+        state.serialize_field("cross_msgs", &cross_msgs)?;
+
+        state.end()
+    }
+}
+
+impl<'a> Serialize for AsJson<&'a BatchCrossMsgs> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let BatchCrossMsgs { cross_msgs, fee } = self.0;
+
+        let mut state = serializer.serialize_struct("BatchCrossMsgs", 2)?;
+        state.serialize_field("fee", fee)?;
+
+        if let Some(cross_msgs) = cross_msgs {
+            let vs = cross_msgs.iter().map(|c| {
+                serde_json::json!({
+                    "from": c.msg.from.to_string().unwrap(), // safe to unwrap
+                    "to": c.msg.to.to_string().unwrap(), // safe to unwrap
+                    "method": c.msg.method,
+                    "params": base64::engine::general_purpose::STANDARD.encode(c.msg.params.bytes()),
+                    "value": c.msg.value.atto().to_u64().unwrap_or_default(),
+                    "nonce": c.msg.nonce,
+                })
+            })
+                .collect::<Vec<_>>();
+            state.serialize_field("cross_msgs", &vs)?;
+        } else {
+            state.serialize_field::<Vec<serde_json::Value>>("cross_msgs", &vec![])?;
+        };
+
+        state.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::serialization::AsJson;
+    use ipc_gateway::BottomUpCheckpoint;
+    use ipc_sdk::subnet_id::ROOTNET_ID;
+
+    #[test]
+    fn test_serialization() {
+        let cp = BottomUpCheckpoint::new(ROOTNET_ID.clone(), 10);
+        let v = serde_json::to_string(&AsJson(cp)).unwrap();
+        println!("{v:}");
+    }
+}

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -1,0 +1,11 @@
+// Copyright 2022-2023 Protocol Labs
+//! Handles the serialization of different types between actor cbor tuple serialization and json rpc
+//! json serialization.
+
+mod checkpoint;
+
+/// The trait to implement is we want to serialize directly to json. Most of the types should have no
+/// need to implement this trait. But some types that are shared between actor using cbor tuple serialization
+/// and json rpc response, we are using `AsJson` wrapper to handle convert to json instead.
+#[derive(Debug)]
+pub struct AsJson<T>(pub T);

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -6,8 +6,10 @@
 
 mod checkpoint;
 
-/// The trait to implement is we want to serialize directly to json. Most of the types should have no
-/// need to implement this trait. But some types that are shared between actor using cbor tuple serialization
-/// and json rpc response, we are using `AsJson` wrapper to handle convert to json instead.
+/// A helper struct to serialize struct to json.
+///
+/// Most of the types should have no need to use this struct. But some types that are shared between
+/// actor, which are using cbor tuple serialization and json rpc response. We are using this wrapper
+/// to handle convert to json instead.
 #[derive(Debug)]
-pub struct AsJson<T>(pub T);
+pub struct SerializeToJson<T>(pub T);

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -1,4 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
+// Copyright 2022-2023 Protocol Labs
 //! Handles the serialization of different types between actor cbor tuple serialization and json rpc
 //! json serialization.
 

--- a/src/server/handlers/manager/list_checkpoints.rs
+++ b/src/server/handlers/manager/list_checkpoints.rs
@@ -8,11 +8,12 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fvm_shared::clock::ChainEpoch;
+use ipc_gateway::BottomUpCheckpoint;
 use ipc_sdk::subnet_id::SubnetID;
 use serde::{Deserialize, Serialize};
 
-use crate::lotus::message::ipc::BottomUpCheckpointWrapper;
 use crate::manager::SubnetManager;
+use crate::serialization::AsJson;
 use crate::server::handlers::manager::check_subnet;
 use crate::server::handlers::manager::subnet::SubnetManagerPool;
 use crate::server::JsonRPCRequestHandler;
@@ -38,7 +39,7 @@ impl ListCheckpointsHandler {
 #[async_trait]
 impl JsonRPCRequestHandler for ListCheckpointsHandler {
     type Request = ListCheckpointsParams;
-    type Response = Vec<BottomUpCheckpointWrapper>;
+    type Response = Vec<AsJson<BottomUpCheckpoint>>;
 
     async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
         let child_subnet_id = SubnetID::from_str(request.subnet_id.as_str())?;
@@ -54,10 +55,14 @@ impl JsonRPCRequestHandler for ListCheckpointsHandler {
         let subnet_config = conn.subnet();
         check_subnet(subnet_config)?;
 
-        let checkpoints: Vec<BottomUpCheckpointWrapper> = conn
+        let checkpoints = conn
             .manager()
             .list_checkpoints(child_subnet_id, request.from_epoch, request.to_epoch)
-            .await?;
+            .await?
+            .into_iter()
+            .map(AsJson)
+            .collect();
+
         Ok(checkpoints)
     }
 }

--- a/src/server/handlers/manager/list_checkpoints.rs
+++ b/src/server/handlers/manager/list_checkpoints.rs
@@ -13,7 +13,7 @@ use ipc_sdk::subnet_id::SubnetID;
 use serde::{Deserialize, Serialize};
 
 use crate::manager::SubnetManager;
-use crate::serialization::AsJson;
+use crate::serialization::SerializeToJson;
 use crate::server::handlers::manager::check_subnet;
 use crate::server::handlers::manager::subnet::SubnetManagerPool;
 use crate::server::JsonRPCRequestHandler;
@@ -39,7 +39,7 @@ impl ListCheckpointsHandler {
 #[async_trait]
 impl JsonRPCRequestHandler for ListCheckpointsHandler {
     type Request = ListCheckpointsParams;
-    type Response = Vec<AsJson<BottomUpCheckpoint>>;
+    type Response = Vec<SerializeToJson<BottomUpCheckpoint>>;
 
     async fn handle(&self, request: Self::Request) -> anyhow::Result<Self::Response> {
         let child_subnet_id = SubnetID::from_str(request.subnet_id.as_str())?;
@@ -60,7 +60,7 @@ impl JsonRPCRequestHandler for ListCheckpointsHandler {
             .list_checkpoints(child_subnet_id, request.from_epoch, request.to_epoch)
             .await?
             .into_iter()
-            .map(AsJson)
+            .map(SerializeToJson)
             .collect();
 
         Ok(checkpoints)


### PR DESCRIPTION
For all checkpoint related interaction with lotus node, we will use direct bytes returned and actor's implementation of deserialization. Once this is tested, we shall remove the wrapper structs.

Also added the serialization to json for `ipc-agent` json rpc server. 

Once tested, we should consider moving `serialization` module to `ipc-actor` repo's `sdk` crate.