### PR TITLE
Improve formatting of commands and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > The InterPlanetary Consensus (IPC) orchestrator.
 
-```bash
+```console
 $ ./bin/ipc-agent --help
 
 The IPC agent command line tool
@@ -44,10 +44,10 @@ To build the IPC Agent you need to have Rust installed in your environment. The 
 
 To build the binary for the IPC agent you need to build the requirements in your environment, clone this repo, and build the binary following these steps:
 ```bash
-$ git clone https://github.com/consensus-shipyard/ipc-agent.git
-$ cd ipc-agent
-$ rustup target add wasm32-unknown-unknown
-$ make build
+git clone https://github.com/consensus-shipyard/ipc-agent.git
+cd ipc-agent
+rustup target add wasm32-unknown-unknown
+make build
 ```
 
 This builds the binary of the IPC agent in the `./bin` folder of your repo. If you want to make the command available everywhere, add this folder to the binary `PATH` of your system. To see if the installation was successfully you can run the following command: 
@@ -63,7 +63,7 @@ With Docker installed, you can then `make install-infra` in the root of the `ipc
 In Unix-based systems, it is highly recommended to include your user in the `docker` group to avoid having to run many of the commands from this tutorial using `sudo`. You can achieve this running:
 ```bash
 $ sudo usermod -aG docker $USER
-$ newgrp docker
+newgrp docker
 ```
 
 ## Connecting to a rootnet
@@ -78,7 +78,7 @@ In order to use the IPC agent with Spacenet we need to have access to a full nod
 With the node running, you are ready to connect the IPC agent to Spacenet. For this, you'll need to get an authentication token for your node and create a wallet for the interaction.
 
 *Example*:
-```bash
+```console
 # Generate auth token to node
 $ ./eudico auth token create --perm admin
 eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.8vIV7pCrWx-nxOBAAw_IayDzrGf22kMjagRYmj_8Qqw
@@ -95,14 +95,14 @@ To be able to interact with Spacenet and run new subnets, some FIL should be pro
 ### Option 2: Local deployment
 To deploy a Example rootnet locally for testing you can use the IPC scripts installed in `./bin/ipc-infra` by running:
 ```bash
-$ ./bin/ipc-infra/run-root-docker-1val.sh <lotus-api-port> <validator-libp2p-port>
+./bin/ipc-infra/run-root-docker-1val.sh <lotus-api-port> <validator-libp2p-port>
 ```
 
 For instance, running `./bin/ipc-infra/run-root-docker-1val.sh 1234 1235` will run a rootnet daemon listening at `localhost:1234`, and a single validator mining in the rootnet listening through its libp2p host in `localhost:1235`.
 
 *Example*:
-```bash
-./bin/ipc-infra/run-root-docker-1val.sh 1234 1235
+```console
+$ ./bin/ipc-infra/run-root-docker-1val.sh 1234 1235
 (...)
 >>> Root daemon running in container: 84711d67cf162e30747c4525d69728c4dea8c6b4b35cd89f6d0947fee14bf908
 >>> Token to /root daemon: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.j94YYOr8_AWhGGHQd0q8JuQVuNhJA017SK9EUkqDOO0
@@ -114,7 +114,7 @@ This information will be relevant to configure our agent to connect to this root
 
 The default config path for the agent is `~/.ipc-agent/config.toml`. The agent will always try to pick up the config from this path unless told otherwise. To populate a Example config file in the default path, you can run the following command:
 ```bash
-$ ./bin/ipc-agent config init
+./bin/ipc-agent config init
 ```
 
 The `/root` section of the agent's `config.toml` must be updated to connect to your node. In the examples above, we need to set the endpoint of our rootnet node to be `127.0.0.1:1234`, and replace the `auth_token` and `account` with the ones provided by our node.
@@ -139,7 +139,7 @@ The IPC agent runs as a foreground daemon process that spawns a new JSON RPC ser
 
 Alternatively, the agent can also be used as a CLI to interact with IPC. Under the hood, this cli sends new commands to the RPC server of the daemon. To run the IPC agent daemon you can run:
 ```bash
-$ ./bin/ipc-agent daemon
+./bin/ipc-agent daemon
 ```
 
 The RPC server of the daemon will be listening to the endpoint determined in the `json_rpc_address` field of the config. If you are looking for your agent to be accessible from Docker or externally, remember to listen on `0.0.0.0` instead of `127.0.0.1` as specified in the default config. 
@@ -147,7 +147,7 @@ The RPC server of the daemon will be listening to the endpoint determined in the
 To check if the agent has connected to the rootnet successfully, you can try using it to create a new wallet.
 
 *Example*:
-```bash
+```console
 $ ./bin/ipc-agent wallet new --key-type bls --subnet /root
 2023-03-30T12:01:11Z INFO  ipc_agent::cli::commands::manager::wallet] created new wallet with address WalletNewResponse { address: "t1om5pijjq5dqic4ccnqqrvv6zgzwrlxf6bh2apvi" } in subnet "/root"
 ```

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ With Docker installed, you can then `make install-infra` in the root of the `ipc
 
 In Unix-based systems, it is highly recommended to include your user in the `docker` group to avoid having to run many of the commands from this tutorial using `sudo`. You can achieve this running:
 ```bash
-$ sudo usermod -aG docker $USER
+sudo usermod -aG docker $USER
 newgrp docker
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,33 +12,33 @@ We assume a Ubuntu Linux instance when discussing prerequisites, but annotate st
 
 * Install basic dependencies [Ubuntu/Debian] ([details](https://lotus.filecoin.io/lotus/install/prerequisites/#supported-platforms))
 ```bash
-$ sudo apt update && sudo apt install build-essential libssl-dev mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang hwloc libhwloc-dev wget ca-certificates gnupg -y 
+sudo apt update && sudo apt install build-essential libssl-dev mesa-opencl-icd ocl-icd-opencl-dev gcc git bzr jq pkg-config curl clang hwloc libhwloc-dev wget ca-certificates gnupg -y 
 ```
 
 * Install Rust [Linux] ([details](https://www.rust-lang.org/tools/install))
 ```bash
-$ curl https://sh.rustup.rs -sSf | sh
-$ source "$HOME/.cargo/env"
-$ rustup target add wasm32-unknown-unknown
+curl https://sh.rustup.rs -sSf | sh
+source "$HOME/.cargo/env"
+rustup target add wasm32-unknown-unknown
 ```
 
 * Install Go [Linux] ([details](https://go.dev/doc/install))
 ```bash
-$ curl -fsSL https://golang.org/dl/go1.19.7.linux-amd64.tar.gz | sudo tar -xz -C /usr/local
-$ echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
+curl -fsSL https://golang.org/dl/go1.19.7.linux-amd64.tar.gz | sudo tar -xz -C /usr/local
+echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
 ```
 
 * Install Docker Engine [Ubuntu] ([details](https://docs.docker.com/engine/install/))
 ```bash
-$ sudo install -m 0755 -d /etc/apt/keyrings
-$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-$ sudo chmod a+r /etc/apt/keyrings/docker.gpg
-$ echo \
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+echo \
   "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-$ sudo apt-get update && sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
-$ sudo usermod -aG docker $USER && newgrp docker
+sudo apt-get update && sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin -y
+sudo usermod -aG docker $USER && newgrp docker
 ```
 
 
@@ -48,17 +48,17 @@ Next, we'll download and build the different components (IPC agent, docker image
 
 * Pick a folder where to build the IPC stack. In this example, we'll go with `~/ipc/`.
 ```bash
-$ mkdir -p ~/ipc/ && cd ~/ipc/ 
+mkdir -p ~/ipc/ && cd ~/ipc/ 
 ```
 * Download and compile the IPC Agent (might take a while)
 ```bash
-$ git clone https://github.com/consensus-shipyard/ipc-agent.git
-$ (cd ipc-agent && make build && make install-infra)
+git clone https://github.com/consensus-shipyard/ipc-agent.git
+(cd ipc-agent && make build && make install-infra)
 ```
 * Download and compile eudico (might take a while)
 ```bash
-$ git clone https://github.com/consensus-shipyard/lotus.git
-$ (cd lotus && make spacenet)
+git clone https://github.com/consensus-shipyard/lotus.git
+(cd lotus && make spacenet)
 ```
 
 
@@ -68,17 +68,17 @@ Let's deploy a eudico instance on Spacenet and configure the IPC Agent to intera
 
 * Start your eudico instance (might take a while to sync the chain)
 ```bash
-$ nohup ./lotus/eudico mir daemon --bootstrap &
+nohup ./lotus/eudico mir daemon --bootstrap &
 ```
 * Get configuration parameters
 ```bash
-$ ./lotus/eudico auth create-token --perm admin
-$ ./lotus/eudico wallet new
+./lotus/eudico auth create-token --perm admin
+./lotus/eudico wallet new
 ```
 * Configure your IPC Agent
 ```bash
-$ ./ipc-agent/bin/ipc-agent config init
-$ nano ~/.ipc-agent/config.toml
+./ipc-agent/bin/ipc-agent config init
+nano ~/.ipc-agent/config.toml
 ```
 * Replace the content of `config.toml` with the text below, substituting the token and wallet retrieved above.
 ```toml
@@ -95,7 +95,7 @@ accounts = ["<WALLET_0>"]
 ```
 * Start your IPC Agent
 ```bash
-$ nohup ./ipc-agent/bin/ipc-agent daemon &
+nohup ./ipc-agent/bin/ipc-agent daemon &
 ```
 
 
@@ -108,7 +108,7 @@ $ nohup ./ipc-agent/bin/ipc-agent daemon &
 
 * The next step is to create a subnet under `/root`
 ```bash
-$ ./ipc-agent/bin/ipc-agent subnet create --parent /root --name andromeda --min-validator-stake 1 --min-validators 2 --bottomup-check-period 30 --topdown-check-period 30
+./ipc-agent/bin/ipc-agent subnet create --parent /root --name andromeda --min-validator-stake 1 --min-validators 2 --bottomup-check-period 30 --topdown-check-period 30
 ```
 * Make a note of the address of the subnet you created (`/root/<SUBNET_ID>`)
 
@@ -119,21 +119,21 @@ Although we set a minimum of 2 active validators in the previous, we'll deploy 3
 
 * First, we'll need to create a wallet for each validator
 ```bash
-$ ./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1 --subnet /root
-$ ./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1 --subnet /root
-$ ./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1 --subnet /root
+./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1 --subnet /root
+./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1 --subnet /root
+./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1 --subnet /root
 ```
 * Export each wallet (WALLET_1, WALLET_2, and WALLET_3) by substituting their addresses below
 ```bash
-$ ./lotus/eudico wallet export --lotus-json <WALLET_1> > ~/.ipc-agent/wallet1.key
-$ ./lotus/eudico wallet export --lotus-json <WALLET_2> > ~/.ipc-agent/wallet2.key
-$ ./lotus/eudico wallet export --lotus-json <WALLET_3> > ~/.ipc-agent/wallet3.key
+./lotus/eudico wallet export --lotus-json <WALLET_1> > ~/.ipc-agent/wallet1.key
+./lotus/eudico wallet export --lotus-json <WALLET_2> > ~/.ipc-agent/wallet2.key
+./lotus/eudico wallet export --lotus-json <WALLET_3> > ~/.ipc-agent/wallet3.key
 ```
 * We also need to fund the wallets with enough collateral to; we'll send the funds from our default wallet 
 ```bash
-$ ./ipc-agent/bin/ipc-agent subnet send-value --subnet /root --to <WALLET_1> 2
-$ ./ipc-agent/bin/ipc-agent subnet send-value --subnet /root --to <WALLET_2> 2
-$ ./ipc-agent/bin/ipc-agent subnet send-value --subnet /root --to <WALLET_3> 2
+./ipc-agent/bin/ipc-agent subnet send-value --subnet /root --to <WALLET_1> 2
+./ipc-agent/bin/ipc-agent subnet send-value --subnet /root --to <WALLET_2> 2
+./ipc-agent/bin/ipc-agent subnet send-value --subnet /root --to <WALLET_3> 2
 ```
 
 
@@ -143,9 +143,9 @@ We can deploy the subnet nodes. Note that each node should be importing a differ
 
 * Deploy and run a container for each validator, importing the corresponding wallet keys
 ```bash
-$ ./ipc-agent/bin/ipc-infra/run-subnet-docker.sh 1251 1351 /root/<SUBNET_ID> ~/.ipc-agent/wallet1.key
-$ ./ipc-agent/bin/ipc-infra/run-subnet-docker.sh 1252 1352 /root/<SUBNET_ID> ~/.ipc-agent/wallet2.key
-$ ./ipc-agent/bin/ipc-infra/run-subnet-docker.sh 1253 1353 /root/<SUBNET_ID> ~/.ipc-agent/wallet3.key
+./ipc-agent/bin/ipc-infra/run-subnet-docker.sh 1251 1351 /root/<SUBNET_ID> ~/.ipc-agent/wallet1.key
+./ipc-agent/bin/ipc-infra/run-subnet-docker.sh 1252 1352 /root/<SUBNET_ID> ~/.ipc-agent/wallet2.key
+./ipc-agent/bin/ipc-infra/run-subnet-docker.sh 1253 1353 /root/<SUBNET_ID> ~/.ipc-agent/wallet3.key
 ```
 * If the deployment is successful, each of these nodes should return the following output at the end of their logs. Save the information for the next step.
 ```
@@ -165,12 +165,12 @@ For ease of use, we'll import the remaining keys into the first validator, via w
 
 * Copy the wallet keys into the docker container and import them
 ```bash
-$ docker cp ~/.ipc-agent/wallet2.key <CONTAINER_NAME_1>:/input.key && docker exec -it <CONTAINER_NAME_1> eudico wallet import --format=json-lotus input.key
-$ docker cp ~/.ipc-agent/wallet3.key <CONTAINER_NAME_1>:/input.key && docker exec -it <CONTAINER_NAME_1> eudico wallet import --format=json-lotus input.key
+docker cp ~/.ipc-agent/wallet2.key <CONTAINER_NAME_1>:/input.key && docker exec -it <CONTAINER_NAME_1> eudico wallet import --format=json-lotus input.key
+docker cp ~/.ipc-agent/wallet3.key <CONTAINER_NAME_1>:/input.key && docker exec -it <CONTAINER_NAME_1> eudico wallet import --format=json-lotus input.key
 ```
 * Edit the IPC agent configuration `config.toml`
 ```bash
-$ nano ~/.ipc-agent/config.toml
+nano ~/.ipc-agent/config.toml
 ```
 * Append the new subnet to the configuration
 ```toml
@@ -184,7 +184,7 @@ accounts = ["<WALLET_1>", "<WALLET_2>", "<WALLET_3>"]
 ```
 * Reload the config
 ```bash 
-$ ./ipc-agent/bin/ipc-agent config reload
+./ipc-agent/bin/ipc-agent config reload
 ```
 
 
@@ -194,9 +194,9 @@ All the infrastructure for the subnet is now deployed, and we can join our valid
 
 * Join the subnet with each validators
 ```bash
-$ ./ipc-agent/bin/ipc-agent subnet join --from <WALLET_1> --subnet /root/<SUBNET_ID> --collateral 1 --validator-net-addr <VALIDATOR_ADDR_1>
-$ ./ipc-agent/bin/ipc-agent subnet join --from <WALLET_2> --subnet /root/<SUBNET_ID> --collateral 1 --validator-net-addr <VALIDATOR_ADDR_2>
-$ ./ipc-agent/bin/ipc-agent subnet join --from <WALLET_3> --subnet /root/<SUBNET_ID> --collateral 1 --validator-net-addr <VALIDATOR_ADDR_3>
+./ipc-agent/bin/ipc-agent subnet join --from <WALLET_1> --subnet /root/<SUBNET_ID> --collateral 1 --validator-net-addr <VALIDATOR_ADDR_1>
+./ipc-agent/bin/ipc-agent subnet join --from <WALLET_2> --subnet /root/<SUBNET_ID> --collateral 1 --validator-net-addr <VALIDATOR_ADDR_2>
+./ipc-agent/bin/ipc-agent subnet join --from <WALLET_3> --subnet /root/<SUBNET_ID> --collateral 1 --validator-net-addr <VALIDATOR_ADDR_3>
 ```
 
 
@@ -204,9 +204,9 @@ $ ./ipc-agent/bin/ipc-agent subnet join --from <WALLET_3> --subnet /root/<SUBNET
 
 We have everything in place now to start validating. This is as simple as running the following script for each of the validators, passing the container name (or id):
 ```bash
-$ nohup ./ipc-agent/bin/ipc-infra/mine-subnet.sh <CONTAINER_NAME_1> &
-$ nohup ./ipc-agent/bin/ipc-infra/mine-subnet.sh <CONTAINER_NAME_2> &
-$ nohup ./ipc-agent/bin/ipc-infra/mine-subnet.sh <CONTAINER_NAME_3> &
+nohup ./ipc-agent/bin/ipc-infra/mine-subnet.sh <CONTAINER_NAME_1> &
+nohup ./ipc-agent/bin/ipc-infra/mine-subnet.sh <CONTAINER_NAME_2> &
+nohup ./ipc-agent/bin/ipc-infra/mine-subnet.sh <CONTAINER_NAME_3> &
 ```
 
 
@@ -214,7 +214,7 @@ $ nohup ./ipc-agent/bin/ipc-infra/mine-subnet.sh <CONTAINER_NAME_3> &
 
 * Check that the subnet is running
 ```bash
-$ ./ipc-agent/bin/ipc-agent subnet list --gateway-address t064 --subnet /root
+./ipc-agent/bin/ipc-agent subnet list --gateway-address t064 --subnet /root
 ```
 * If something went wrong, please have a look at the [README](https://github.com/consensus-shipyard/ipc-agent). If it doesn't help, please join us in #ipc-help. In either case, let us know your experience!
 * Please note that to repeat this guide or spawn a new subnet, you may need to change the parameters or reset your system.

--- a/docs/subnet.md
+++ b/docs/subnet.md
@@ -14,16 +14,18 @@ In order to run a validator in a subnet, we'll need a set of keys to handle that
 
 *Example*:
 ```bash
-$ ./eudico wallet export --lotus-json <address-to-export> > <output file>
-
+./eudico wallet export --lotus-json <address-to-export> > <output file>
+```
+```console
 # Example execution
 $ ./eudico wallet export --lotus-json t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq > ~/.ipc-agent/wallet.key
 ```
 
 If your daemon is running on a docker container, you can get the container id or name (provided also in the output of the infra scripts), and run the following command above inside a container outputting the exported private key into a file locally:
 ```bash
-$ docker exec -it <container-id> eudico wallet export --lotus-json <adress-to-export> > ~/.ipc-agent/wallet.key
-
+docker exec -it <container-id> eudico wallet export --lotus-json <adress-to-export> > ~/.ipc-agent/wallet.key
+```
+```console
 # Example execution
 $ docker exec -it ipc_root_1234 eudico wallet export --lotus-json t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq > ~/.ipc-agent/wallet.key
 ```
@@ -34,16 +36,18 @@ Depending on whether the subnet is running inside a docker container or not, you
 
 ```bash
 # Bare: Import directly into eudico
-$ ./eudico wallet import --lotus-json <wallet-key-file-path>
-
+./eudico wallet import --lotus-json <wallet-key-file-path>
+```
+```console
 # Example execution
 $ ./eudico wallet import --lotus-json ~/.ipc-agent/wallet.key
 ```
 
 ```bash
 # Docker: Copy the wallet key into the container and import into eudico
-$ docker cp <wallet-key-path> <container-id>:<target-file-in-container> && docker exec -it <container-id> eudico wallet import --format=json-lotus <target-file-in-container>
-
+docker cp <wallet-key-path> <container-id>:<target-file-in-container> && docker exec -it <container-id> eudico wallet import --format=json-lotus <target-file-in-container>
+```
+```console
 # Example execution
 $ docker cp ~/.ipc-agent/wallet.key ipc_root_t01002_1250:/input.key && docker exec -it ipc_root_t01002_1250 eudico wallet import --format=json-lotus input.key
 ```
@@ -57,8 +61,9 @@ This section provides instructions for spawning a simple subnet with a single va
 To run a subnet the first thing is to configure and create the subnet actor that will govern the subnet's operation.
 
 ```bash
-$ ./bin/ipc-agent subnet create --parent <parent> --name <name> --min-validator-stake <min_validator_stake> --min-validators <min-validators> --bottomup-check-period <bottomup-check-period> --topdown-check-period <topdown-check-period>
-
+./bin/ipc-agent subnet create --parent <parent> --name <name> --min-validator-stake <min_validator_stake> --min-validators <min-validators> --bottomup-check-period <bottomup-check-period> --topdown-check-period <topdown-check-period>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent subnet create --parent /root --name test --min-validator-stake 1 --min-validators 0 --bottomup-check-period 30 --topdown-check-period 30
 [2023-03-21T09:32:58Z INFO  ipc_agent::cli::commands::manager::create] created subnet actor with id: /root/t01002
@@ -73,8 +78,9 @@ We will need to export the wallet key from our root node so that we can import t
 
 Before joining a new subnet, our node for that subnet must  be initialised. For the deployment of subnet daemons we also provide a convenient infra script:
 ```bash
-$ ./bin/ipc-infra/run-subnet-docker.sh <lotus-api-port> <validator-libp2p-port> <subnet-id> <absolute-path-validator-key>
-
+./bin/ipc-infra/run-subnet-docker.sh <lotus-api-port> <validator-libp2p-port> <subnet-id> <absolute-path-validator-key>
+```
+```console
 # Example execution
 $ ./bin/ipc-infra/run-subnet-docker.sh 1250 1350 /root/t01002 ~/.ipc-agent/wallet.key
 (...)
@@ -106,8 +112,9 @@ accounts = ["t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq"]
 
 With the daemon for the subnet deployed, we can join the subnet:
 ```bash
-$ ./bin/ipc-agent subnet join --subnet <subnet-id> --collateral <collateral_amount> --validator-net-addr <libp2p-add-validator>
-
+./bin/ipc-agent subnet join --subnet <subnet-id> --collateral <collateral_amount> --validator-net-addr <libp2p-add-validator>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent subnet join --subnet /root/t01002 --collateral 2 --validator-net-addr /dns/host.docker.internal/tcp/1349/p2p/12D3KooWN5hbWkCxwvrX9xYxMwFbWm2Jpa1o4qhwifmSw3Fb
 ```
@@ -117,8 +124,9 @@ This command specifies the subnet to join, the amount of collateral to provide a
 
 With our subnet daemon deployed, and having joined the network, as the minimum number of validators we set for our subnet is 0, we can start mining and creating new blocks in the subnet. Doing so is a simple as running the following script using as an argument the container of our subnet node: 
 ```bash
-$  ./bin/ipc-infra/mine-subnet.sh <node-container-id>
-
+./bin/ipc-infra/mine-subnet.sh <node-container-id>
+```
+```console
 # Example execution
 $  ./bin/ipc-infra/mine-subnet.sh 84711d67cf162e30747c4525d69728c4dea8c6b4b35cd89f6d0947fee14bf908
 ```
@@ -129,12 +137,12 @@ The mining process is currently run in the foreground in interactive mode. Consi
 
 In this section, we will deploy a subnet where the IPC agent is responsible for handling more than one validator in the subnet. We are going to deploy a subnet with 3 validators. The first thing we'll need to do is create a new wallet for every validator we want to run. We can do this directly through the agent with the following command (3x):
 ```bash
-$ ./bin/ipc-agent wallet new --key-type secp256k1 --subnet /root
+./bin/ipc-agent wallet new --key-type secp256k1 --subnet /root
 ```
 
 We also need to provide with some funds our wallets so they can put collateral to join the subnet. According to the rootnet you are connected to, you may need to get some funds from the faucet, or send some from your main wallet. Funds can be sent from your main wallet also through the agent with (3x, adjusting `target-wallet` for each): 
 ```bash
-$ ./bin/ipc-agent subnet send-value --subnet /root --to <target-wallet> <amount_FIL>
+./bin/ipc-agent subnet send-value --subnet /root --to <target-wallet> <amount_FIL>
 ```
 
 With this, we can already create the subnet with `/root` as its parent. We are going to set the `--min-validators 2` so no new blocks can be created without this number of validators in the subnet.
@@ -145,18 +153,21 @@ With this, we can already create the subnet with `/root` as its parent. We are g
 
 In order to deploy the 3 validators for the subnet, we will have to first export the keys from our root node so we can import them to our validators. Depending on how you are running your rootnet node you'll have to make a call to the docker container, or your nodes API. More information about exporting keys from your node can be found under [this section](#Exporting-wallet-keys).
 
-With the keys conveniently exported, we can deploy the subnet nodes using the `infra-scripts`. The following code snippet showcases the deployment of five Example nodes. Note that each node should be importing a different wallet key for their validator, and should be exposing different ports for their API and validators.
+With the keys conveniently exported, we can deploy the subnet nodes using the `infra-scripts`. Note that each node should be importing a different wallet key for their validator, and should be exposing different ports for their API and validators.
 
-*Example*:
 ```bash
-$ ./bin/ipc-infra/run-subnet-docker.sh 1251 1351 /root/t01002 ~/.ipc-agent/wallet1.key
-$ ./bin/ipc-infra/run-subnet-docker.sh 1252 1352 /root/t01002 ~/.ipc-agent/wallet2.key
-$ ./bin/ipc-infra/run-subnet-docker.sh 1253 1353 /root/t01002 ~/.ipc-agent/wallet3.key
+./bin/ipc-infra/run-subnet-docker.sh <api_port> <validator_port> <subnet_id> <path_to_key>
+```
+```console
+# Example execution
+./bin/ipc-infra/run-subnet-docker.sh 1251 1351 /root/t01002 ~/.ipc-agent/wallet1.key
+./bin/ipc-infra/run-subnet-docker.sh 1252 1352 /root/t01002 ~/.ipc-agent/wallet2.key
+./bin/ipc-infra/run-subnet-docker.sh 1253 1353 /root/t01002 ~/.ipc-agent/wallet3.key
 ```
 If the deployment is successful, each of these nodes should return the following output at the end of their logs. Note down this information somewhere as we will need it to conveniently join our validators to the subnet.
 
 *Example*:
-```
+```console
 >>> Subnet /root/t01002 daemon running in container: 91d2af80534665a8d9a20127e480c16136d352a79563e74ee3c5497d50b9eda8 (friendly name: ipc_root_t01002_1240)
 >>> Token to /root/t01002 daemon: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.JTiumQwFIutkTb0gUC5JWTATs-lUvDaopEDE0ewgzLk
 >>> Default wallet: t1ivy6mo2ofxw4fdmft22nel66w63fb7cuyslm4cy
@@ -186,17 +197,18 @@ All the infrastructure for the subnet is now deployed, and we can join our valid
 
 This is the command that needs to be executed for every validator to join the subnet:
 ```bash
-$ ./bin/ipc-agent subnet join --from <validator-wallet> --subnet /root/t01002 --collateral <amount-collateral> --validator-net-addr <validator-addr>
-
+./bin/ipc-agent subnet join --from <validator-wallet> --subnet /root/t01002 --collateral <amount-collateral> --validator-net-addr <validator-addr>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent subnet join --from t1ivy6mo2ofxw4fdmft22nel66w63fb7cuyslm4cy --subnet /root/t01002 --collateral 2 --validator-net-addr /dns/host.docker.internal/tcp/1359/p2p/12D3KooWEJXcSPw6Yv4jDk52xvp2rdeG3J6jCPX9AgBJE2mRCVoR
 ```
 Remember doing the above step for the 3 validators.
 
-### Mining in subnet
+### Mining in a subnet
 We have everything in place now to start mining. Mining is as simple as running the following script for each of the validators, passing the container id/name:
-```bash
-$  ./bin/ipc-infra/mine-subnet.sh <node-container-id>
+```bash 
+./bin/ipc-infra/mine-subnet.sh <node-container-id>
 ```
 
 The mining process is currently run in the foreground in interactive mode. Consider using `nohup ./bin/ipc-infra/mine-subnet.sh` or screen to run the process in the background and redirect the logs to some file as handling the mining process of the three validators in the foreground may be quite cumbersome.

--- a/docs/subnet.md
+++ b/docs/subnet.md
@@ -160,9 +160,9 @@ With the keys conveniently exported, we can deploy the subnet nodes using the `i
 ```
 ```console
 # Example execution
-./bin/ipc-infra/run-subnet-docker.sh 1251 1351 /root/t01002 ~/.ipc-agent/wallet1.key
-./bin/ipc-infra/run-subnet-docker.sh 1252 1352 /root/t01002 ~/.ipc-agent/wallet2.key
-./bin/ipc-infra/run-subnet-docker.sh 1253 1353 /root/t01002 ~/.ipc-agent/wallet3.key
+$ ./bin/ipc-infra/run-subnet-docker.sh 1251 1351 /root/t01002 ~/.ipc-agent/wallet1.key
+$ ./bin/ipc-infra/run-subnet-docker.sh 1252 1352 /root/t01002 ~/.ipc-agent/wallet2.key
+$ ./bin/ipc-infra/run-subnet-docker.sh 1253 1353 /root/t01002 ~/.ipc-agent/wallet3.key
 ```
 If the deployment is successful, each of these nodes should return the following output at the end of their logs. Note down this information somewhere as we will need it to conveniently join our validators to the subnet.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,11 +7,11 @@
 Sometimes, things break, and we'll need to push a quick path to fix some bug. If this happens, and you need to upgrade your agent version, kill you agent daemon if you have any running, pull the latest changes from this repo, build the binary, and start your daemon again. This should pick up the latest version for the agent. In the future, we will provide a better way to upgrade your agent.
 ```bash
 # Pull latest changes
-$ git pull
+git pull
 # Build the agent
-$ make build
+make build
 # Restart the daemon
-$ ./bin/ipc-agent daemon
+./bin/ipc-agent daemon
 ```
 
 ## The eudico image is not building successful 
@@ -26,11 +26,12 @@ Either because the dockerized subnet node after running `./bin/ipc-infra/run-sub
 ```
 Not online yet... (could not get API info for FullNode: could not get api endpoint: API not running (no endpoint))
 ```
-Or because when the script finishes no validator address has been reported as expected by the logs, the best way to debug this situation is to attach to the docker container and check the logs with the following command:
+Or because when the script finishes no validator address has been reported as expected by the logs, the best way to debug this situation is to attach to the docker container:
 ```bash
-$ docker exec -it <container_name> bash
-
-# Inside the container
+docker exec -it <container_name> bash
+```
+ And check the logs with the following command, inside the container
+```bash
 tmux a
 ```
 Generally, the issue is that:
@@ -47,8 +48,9 @@ It may be the case that while joining the subnet, you didn't set the multiaddres
 
 Changing the validator is as simple as running the following command:
 ```bash
-$ ./bin/ipc-agent subnet set-validator-net-addr --subnet <subnet-id> --validator-net-addr <new-validator-addr>
-
+./bin/ipc-agent subnet set-validator-net-addr --subnet <subnet-id> --validator-net-addr <new-validator-addr>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent subnet set-validator-net-addr --subnet /root/t01002 --validator-net-addr "/dns/host.docker.internal/tcp/1349/p2p/12D3KooWDeN3bTvZEH11s9Gq5bDeZZLKgRZiMDcy2KmA6mUaT9KE"
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,8 +7,9 @@
 As a sanity-check that we have joined the subnet successfully and that we provided enough collateral to register the subnet to IPC, we can list the child subnets of our parent with the following command:
 
 ```bash
-$ ./bin/ipc-agent list-subnets --gateway-address=<gateway-addr> --subnet=<parent-subnet-id>
-
+./bin/ipc-agent list-subnets --gateway-address=<gateway-addr> --subnet=<parent-subnet-id>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent list-subnets --gateway-address=t064 --subnet=/root
 [2023-03-30T17:00:25Z INFO  ipc_agent::cli::commands::manager::list_subnets] /root/t01003 - status: 0, collateral: 2 FIL, circ.supply: 0.0 FIL
@@ -20,8 +21,9 @@ This command only shows subnets that have been registered to the gateway, i.e. t
 
 With the daemon for a subnet deployed (see [instructions](/docs/subnet.md)), one can join the subnet:
 ```bash
-$ ./bin/ipc-agent subnet join --subnet <subnet-id> --collateral <collateral_amount> --validator-net-addr <libp2p-add-validator>
-
+./bin/ipc-agent subnet join --subnet <subnet-id> --collateral <collateral_amount> --validator-net-addr <libp2p-add-validator>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent subnet join --subnet /root/t01002 --collateral 2 --validator-net-addr /dns/host.docker.internal/tcp/1349/p2p/12D3KooWN5hbWkCxwvrX9xYxMwFbWm2Jpa1o4qhwifmSw3Fb
 ```
@@ -30,8 +32,9 @@ This command specifies the subnet to join, the amount of collateral to provide a
 ## Listing your balance in a subnet
 In order to send messages in a subnet, you'll need to have funds in your subnt account. You can use the following command to list the balance of your wallets in a subnet:
 ```bash
-$ ./bin/ipc-agent wallet list --subnet=<subnet-id>
-
+./bin/ipc-agent wallet list --subnet=<subnet-id>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent wallet list --subnet=/root/t01002
 ipc_agent::cli::commands::wallet::list] wallets in subnet /root are {"t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq": "500.0"}
@@ -41,8 +44,9 @@ ipc_agent::cli::commands::wallet::list] wallets in subnet /root are {"t1cp4q4lqs
 
 The agent provides a command to conveniently exchange funds between addresses of the same subnet. This can be achieved through the following command:
 ```bash
-$ ./bin/ipc-agent subnet send-value --subnet <subnet-id> --to <to-addr> <value>
-
+./bin/ipc-agent subnet send-value --subnet <subnet-id> --to <to-addr> <value>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent subnet send-value --subnet /root/t01002 --to t1xbevqterae2tanmh2kaqksnoacflrv6w2dflq4i 10
 ```
@@ -60,11 +64,11 @@ Complex behavior can be implemented using these primitives: sending value to a u
 ### Fund
 Funding a subnet can be performed by using the following command:
 ```bash
-$ ./bin/ipc-agent cross-msg fund --subnet=<subnet-id> <amount>
-
+./bin/ipc-agent cross-msg fund --subnet=<subnet-id> <amount>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent cross-msg fund --subnet=/root/t01002 100
-
 ```
 This command includes the cross-net message into the next top-down checkpoint after the current epoch. Once the top-down checkpoint is committed, you should see the funds in your account of the child subnet.
 
@@ -73,8 +77,9 @@ This command includes the cross-net message into the next top-down checkpoint af
 ### Release
 In order to release funds from a subnet, your account must hold enough funds inside it. Releasing funds to the parent subnet can be permformed with the following comand:
 ```bash
-$ ./bin/ipc-agent cross-msg release --subnet=<subnet-id> <amount>
-
+./bin/ipc-agent cross-msg release --subnet=<subnet-id> <amount>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent cross-msg release --subnet=/root/t01002 100
 ```
@@ -85,9 +90,9 @@ This command includes the cross-net message into a bottom-up checkpoint after th
 
 Subnets are periodically committing checkpoints to their parent every `bottomup-check-period` (parameter defined when creating the subnet). If you want to inspect the information of a range of bottom-up checkpoints committed in the parent for a subnet, you can use the `checkpoint list-bottomup` command provided by the agent as follows: 
 ```bash
-# List checkpoints between two epochs for a subnet
-$ ./bin/ipc-agent checkpoint list-bottomup --from-epoch <range-start> --to-epoch <range-end> --subnet <subnet-id>
-
+./bin/ipc-agent checkpoint list-bottomup --from-epoch <range-start> --to-epoch <range-end> --subnet <subnet-id>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent checkpoint list-bottomup --from-epoch 0 --to-epoch 100 --subnet /root/t01002
 [2023-03-29T12:43:42Z INFO  ipc_agent::cli::commands::manager::list_checkpoints] epoch 0 - prev_check={"/":"bafy2bzacedkoa623kvi5gfis2yks7xxjl73vg7xwbojz4tpq63dd5jpfz757i"}, cross_msgs=null, child_checks=null
@@ -99,8 +104,9 @@ You can find the checkpoint where your cross-message was included by listing the
 ## Checking the health of top-down checkpoints
 In order to check the health of top-down checkpointing in a subnet, the following command can be run:
 ```bash
-$./bin/ipc-agent checkpoint last-topdown --subnet=<subnet-id>
-
+./bin/ipc-agent checkpoint last-topdown --subnet=<subnet-id>
+```
+```console
 # Example execution
 $./bin/ipc-agent checkpoint last-topdown --subnet /root/t01002
 [2023-04-18T17:11:34Z INFO  ipc_agent::cli::commands::checkpoint::topdown_executed] Last top-down checkpoint executed in epoch: 9866
@@ -108,13 +114,13 @@ $./bin/ipc-agent checkpoint last-topdown --subnet /root/t01002
 
 This command returns the epoch of the last top-down checkpoint executed in the child. If you see that this epoch is way below the current epoch of the parent subnet, then top-down checkpointing may be lagging, validators need to catch-up, and the forwarding of top-down messages (from parent to child) may take longer to be committed.
 
-
 ## Leaving a subnet
 
 To leave a subnet, the following agent command can be used:
 ```bash
-$ ./bin/ipc-agent subnet leave --subnet <subnet-id>
-
+./bin/ipc-agent subnet leave --subnet <subnet-id>
+```
+```console
 # Example execution
 $ ./bin/ipc-agent subnet leave --subnet /root/t01002
 ```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -108,7 +108,7 @@ In order to check the health of top-down checkpointing in a subnet, the followin
 ```
 ```console
 # Example execution
-$./bin/ipc-agent checkpoint last-topdown --subnet /root/t01002
+$ ./bin/ipc-agent checkpoint last-topdown --subnet /root/t01002
 [2023-04-18T17:11:34Z INFO  ipc_agent::cli::commands::checkpoint::topdown_executed] Last top-down checkpoint executed in epoch: 9866
 ```
 


### PR DESCRIPTION
* Removes leading prompt from bash blocks
* Separates examples into console blocks

This was a bit rushed so some decisions may have been suboptimal given there are some edge cases.

For the now-separate examples, we should add the expected outcome -- which we have in some cases, not in others. But this should already improve quality of life for the reader, so I wouldn't block on re-executing things for output.