### PR TITLE
Recover hasVoted after fix

### DIFF
--- a/src/manager/bottomup.rs
+++ b/src/manager/bottomup.rs
@@ -105,20 +105,16 @@ pub async fn manage_bottomup_checkpoints(
                 for account in child.accounts.iter() {
                     if validator_set.contains(account) {
                         // check if the validator already voted
-                        // let has_voted = parent_client
-                        //     .ipc_validator_has_voted_bottomup(&child.id, submission_epoch, account)
-                        //     .await
-                        //     .map_err(|e| {
-                        //         log::error!(
-                        //             "error checking if validator has voted in subnet: {:?}",
-                        //             &child.id
-                        //         );
-                        //         e
-                        //     })?;
-                        // FIXME: There is a nasty bug in the de-serialization of EpochVoteSubmissions in
-                        // the actor due to the fact that we are using Cids and nodes can't be load.
-                        // commenting for now, but needs to be fixed in actors.
-                        let has_voted = false;
+                        let has_voted = parent_client
+                            .ipc_validator_has_voted_bottomup(&child.id, submission_epoch, account)
+                            .await
+                            .map_err(|e| {
+                                log::error!(
+                                    "error checking if validator has voted in subnet: {:?}",
+                                    &child.id
+                                );
+                                e
+                            })?;
                         if !has_voted {
                             // submitting the checkpoint synchronously and waiting to be committed.
                             let r = submit_checkpoint(

--- a/src/manager/topdown.rs
+++ b/src/manager/topdown.rs
@@ -100,26 +100,22 @@ pub async fn manage_topdown_checkpoints(
                     if validator_set.contains(account) {
                         // check if the validator already voted the top-down checkpoint
                         // in the child.
-                        // let has_voted = child_client
-                        //     .ipc_validator_has_voted_topdown(
-                        //         // FIXME: Do not use the default, use the one configured
-                        //         // for the subnet
-                        //         &Address::from_str(GATEWAY_ACTOR_ADDRESS)?,
-                        //         submission_epoch,
-                        //         account,
-                        //     )
-                        //     .await
-                        //     .map_err(|e| {
-                        //         log::error!(
-                        //             "error checking if validator has voted in subnet: {:?}",
-                        //             &child.id
-                        //         );
-                        //         e
-                        //     })?;
-                        // FIXME: There is a nasty bug in the de-serialization of EpochVoteSubmissions in
-                        // the actor due to the fact that we are using Cids and nodes can't be load.
-                        // commenting for now, but needs to be fixed in actors.
-                        let has_voted = false;
+                        let has_voted = child_client
+                            .ipc_validator_has_voted_topdown(
+                                // FIXME: Do not use the default, use the one configured
+                                // for the subnet
+                                &Address::from_str(GATEWAY_ACTOR_ADDRESS)?,
+                                submission_epoch,
+                                account,
+                            )
+                            .await
+                            .map_err(|e| {
+                                log::error!(
+                                    "error checking if validator has voted in subnet: {:?}",
+                                    &child.id
+                                );
+                                e
+                            })?;
 
                         if !has_voted {
                             // submitting the checkpoint synchronously and waiting to be committed.


### PR DESCRIPTION
Depends on: https://github.com/consensus-shipyard/ipc-actors/pull/100

After fixing the serialization issue that existed when more than one validator had voted the same checkpoint, we can recover the `hasVote` check in checkpoints to avoid the errors some users are seeing on their agents.