### PR TITLE
Replace u64 with f64 for FIL amount

### DIFF
--- a/src/cli/commands/crossmsg/fund.rs
+++ b/src/cli/commands/crossmsg/fund.rs
@@ -50,6 +50,6 @@ pub(crate) struct FundArgs {
     pub from: Option<String>,
     #[arg(long, short, help = "The subnet to fund")]
     pub subnet: String,
-    #[arg(help = "The amount to fund in FIL")]
-    pub amount: u64,
+    #[arg(help = "The amount to fund in FIL, in whole FIL")]
+    pub amount: f64,
 }

--- a/src/cli/commands/crossmsg/release.rs
+++ b/src/cli/commands/crossmsg/release.rs
@@ -49,6 +49,6 @@ pub(crate) struct ReleaseArgs {
     pub from: Option<String>,
     #[arg(long, short, help = "The subnet to release funds from")]
     pub subnet: String,
-    #[arg(help = "The amount to release in FIL")]
-    pub amount: u64,
+    #[arg(help = "The amount to release in FIL, in whole FIL")]
+    pub amount: f64,
 }

--- a/src/cli/commands/subnet/create.rs
+++ b/src/cli/commands/subnet/create.rs
@@ -75,7 +75,7 @@ pub struct CreateSubnetArgs {
     #[arg(long, short, help = "The name of the subnet")]
     pub name: String,
     #[arg(long, help = "The minimal validator stake amount (in whole FIL units)")]
-    pub min_validator_stake: u64,
+    pub min_validator_stake: f64,
     #[arg(long, help = "The minimal number of validators")]
     pub min_validators: u64,
     #[arg(long, help = "The bottom up checkpoint period in number of blocks")]

--- a/src/cli/commands/subnet/join.rs
+++ b/src/cli/commands/subnet/join.rs
@@ -58,7 +58,7 @@ pub struct JoinSubnetArgs {
         short,
         help = "The collateral to stake in the subnet (in whole FIL units)"
     )]
-    pub collateral: u64,
+    pub collateral: f64,
     #[arg(long, short, help = "The validator net address")]
     pub validator_net_addr: String,
 }

--- a/src/cli/commands/subnet/send_value.rs
+++ b/src/cli/commands/subnet/send_value.rs
@@ -55,5 +55,5 @@ pub(crate) struct SendValueArgs {
     #[arg(long, short, help = "The subnet of the addresses")]
     pub subnet: String,
     #[arg(help = "The amount to send (in whole FIL units)")]
-    pub amount: u64,
+    pub amount: f64,
 }

--- a/src/server/handlers/manager/create.rs
+++ b/src/server/handlers/manager/create.rs
@@ -5,11 +5,10 @@
 use crate::manager::SubnetManager;
 use crate::server::handlers::manager::subnet::SubnetManagerPool;
 use crate::server::handlers::manager::{check_subnet, parse_from};
-use crate::server::JsonRPCRequestHandler;
+use crate::server::{handlers, JsonRPCRequestHandler};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
 use ipc_sdk::subnet_id::SubnetID;
 use ipc_subnet_actor::{ConsensusType, ConstructParams};
 use serde::{Deserialize, Serialize};
@@ -21,7 +20,8 @@ pub struct CreateSubnetParams {
     pub from: Option<String>,
     pub parent: String,
     pub name: String,
-    pub min_validator_stake: u64,
+    /// In whole FIL
+    pub min_validator_stake: f64,
     pub min_validators: u64,
     pub bottomup_check_period: ChainEpoch,
     pub topdown_check_period: ChainEpoch,
@@ -64,7 +64,7 @@ impl JsonRPCRequestHandler for CreateSubnetHandler {
             name: request.name,
             ipc_gateway_addr: subnet_config.gateway_addr.id()?,
             consensus: ConsensusType::Mir,
-            min_validator_stake: TokenAmount::from_whole(request.min_validator_stake), // In FIL
+            min_validator_stake: handlers::f64_to_token_amount(request.min_validator_stake)?,
             min_validators: request.min_validators,
             bottomup_check_period: request.bottomup_check_period,
             topdown_check_period: request.topdown_check_period,

--- a/src/server/handlers/manager/fund.rs
+++ b/src/server/handlers/manager/fund.rs
@@ -4,11 +4,10 @@
 
 use crate::manager::SubnetManager;
 use crate::server::handlers::manager::subnet::SubnetManagerPool;
-use crate::server::{check_subnet, parse_from, JsonRPCRequestHandler};
+use crate::server::{check_subnet, handlers, parse_from, JsonRPCRequestHandler};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
 use ipc_sdk::subnet_id::SubnetID;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -18,7 +17,8 @@ use std::sync::Arc;
 pub struct FundParams {
     pub subnet: String,
     pub from: Option<String>,
-    pub amount: u64,
+    /// In whole FIL
+    pub amount: f64,
 }
 
 /// The fund json rpc method handler.
@@ -49,7 +49,7 @@ impl JsonRPCRequestHandler for FundHandler {
         check_subnet(subnet_config)?;
 
         let from = parse_from(subnet_config, request.from)?;
-        let amount = TokenAmount::from_whole(request.amount);
+        let amount = handlers::f64_to_token_amount(request.amount)?;
 
         conn.manager()
             .fund(subnet, subnet_config.gateway_addr, from, amount)

--- a/src/server/handlers/manager/join.rs
+++ b/src/server/handlers/manager/join.rs
@@ -5,10 +5,9 @@
 use crate::manager::SubnetManager;
 use crate::server::handlers::manager::subnet::SubnetManagerPool;
 use crate::server::handlers::manager::{check_subnet, parse_from};
-use crate::server::JsonRPCRequestHandler;
+use crate::server::{handlers, JsonRPCRequestHandler};
 use anyhow::anyhow;
 use async_trait::async_trait;
-use fvm_shared::econ::TokenAmount;
 use ipc_sdk::subnet_id::SubnetID;
 use ipc_subnet_actor::JoinParams;
 use serde::{Deserialize, Serialize};
@@ -19,7 +18,8 @@ use std::sync::Arc;
 pub struct JoinSubnetParams {
     pub subnet: String,
     pub from: Option<String>,
-    pub collateral: u64,
+    /// In whole FIL
+    pub collateral: f64,
     pub validator_net_addr: String,
 }
 
@@ -50,7 +50,7 @@ impl JsonRPCRequestHandler for JoinSubnetHandler {
         let join_params = JoinParams {
             validator_net_addr: request.validator_net_addr,
         };
-        let collateral = TokenAmount::from_whole(request.collateral); // In FIL, not atto
+        let collateral = handlers::f64_to_token_amount(request.collateral)?;
 
         let subnet_config = conn.subnet();
         check_subnet(subnet_config)?;

--- a/src/server/handlers/manager/release.rs
+++ b/src/server/handlers/manager/release.rs
@@ -4,11 +4,10 @@
 
 use crate::manager::SubnetManager;
 use crate::server::handlers::manager::subnet::SubnetManagerPool;
-use crate::server::{check_subnet, parse_from, JsonRPCRequestHandler};
+use crate::server::{check_subnet, handlers, parse_from, JsonRPCRequestHandler};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
 use ipc_sdk::subnet_id::SubnetID;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -18,7 +17,8 @@ use std::sync::Arc;
 pub struct ReleaseParams {
     pub subnet: String,
     pub from: Option<String>,
-    pub amount: u64,
+    /// In whole FIL
+    pub amount: f64,
 }
 
 /// The Release json rpc method handler.
@@ -47,7 +47,7 @@ impl JsonRPCRequestHandler for ReleaseHandler {
         let subnet_config = conn.subnet();
         check_subnet(subnet_config)?;
 
-        let amount = TokenAmount::from_whole(request.amount);
+        let amount = handlers::f64_to_token_amount(request.amount)?;
         let from = parse_from(subnet_config, request.from)?;
 
         conn.manager()

--- a/src/server/handlers/manager/send_value.rs
+++ b/src/server/handlers/manager/send_value.rs
@@ -5,11 +5,10 @@
 use crate::manager::SubnetManager;
 use crate::server::handlers::manager::subnet::SubnetManagerPool;
 use crate::server::handlers::manager::{check_subnet, parse_from};
-use crate::server::JsonRPCRequestHandler;
+use crate::server::{handlers, JsonRPCRequestHandler};
 use anyhow::anyhow;
 use async_trait::async_trait;
 use fvm_shared::address::Address;
-use fvm_shared::econ::TokenAmount;
 use ipc_sdk::subnet_id::SubnetID;
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -47,11 +46,7 @@ impl JsonRPCRequestHandler for SendValueHandler {
             Some(conn) => conn,
         };
 
-        let amount = f64_to_token_amount(request.amount);
-        if !amount.is_positive() {
-            return Err(anyhow!("invalid amount to send: {:}", request.amount));
-        }
-
+        let amount = handlers::f64_to_token_amount(request.amount)?;
         let subnet_config = conn.subnet();
         check_subnet(subnet_config)?;
 
@@ -63,23 +58,5 @@ impl JsonRPCRequestHandler for SendValueHandler {
         conn.manager().send_value(from, to, amount).await?;
 
         Ok(())
-    }
-}
-
-fn f64_to_token_amount(f: f64) -> TokenAmount {
-    let precision = TokenAmount::PRECISION as f64;
-    // no rounding, just the integer part
-    TokenAmount::from_atto(f64::trunc(f * precision) as u64)
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::server::send_value::f64_to_token_amount;
-    use fvm_shared::econ::TokenAmount;
-
-    #[test]
-    fn test_amount() {
-        let amount = f64_to_token_amount(1.2f64);
-        assert_eq!(amount, TokenAmount::from_atto(1200000000000000000u64));
     }
 }

--- a/src/server/handlers/manager/send_value.rs
+++ b/src/server/handlers/manager/send_value.rs
@@ -68,6 +68,7 @@ impl JsonRPCRequestHandler for SendValueHandler {
 
 fn f64_to_token_amount(f: f64) -> TokenAmount {
     let precision = TokenAmount::PRECISION as f64;
+    // no rounding, just the integer part
     TokenAmount::from_atto(f64::trunc(f * precision) as u64)
 }
 

--- a/src/server/handlers/mod.rs
+++ b/src/server/handlers/mod.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 
 pub use config::ReloadConfigParams;
+use fvm_shared::econ::TokenAmount;
 use manager::create::CreateSubnetHandler;
 use manager::join::JoinSubnetHandler;
 use manager::kill::KillSubnetHandler;
@@ -139,5 +140,29 @@ impl Handlers {
         } else {
             Err(anyhow!("method not supported"))
         }
+    }
+}
+
+pub(crate) fn f64_to_token_amount(f: f64) -> anyhow::Result<TokenAmount> {
+    let precision = TokenAmount::PRECISION as f64;
+    // no rounding, just the integer part
+    let amount = TokenAmount::from_atto(f64::trunc(f * precision) as u64);
+
+    if !amount.is_positive() {
+        Err(anyhow!("invalid token amount: {f:}"))
+    } else {
+        Ok(amount)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::server::handlers::f64_to_token_amount;
+    use fvm_shared::econ::TokenAmount;
+
+    #[test]
+    fn test_amount() {
+        let amount = f64_to_token_amount(1.2f64).unwrap();
+        assert_eq!(amount, TokenAmount::from_atto(1200000000000000000u64));
     }
 }

--- a/testing/e2e/src/lib.rs
+++ b/testing/e2e/src/lib.rs
@@ -24,7 +24,7 @@ impl TestClient {
             from: None,
             parent: String::from(parent),
             name: "test".to_string(),
-            min_validator_stake: 1,
+            min_validator_stake: 1.0,
             min_validators: 0,
             bottomup_check_period: 10,
             topdown_check_period: 10,
@@ -45,7 +45,7 @@ impl TestClient {
                 ipc_agent_url: self.json_rpc_url.clone(),
                 from: None,
                 subnet: subnet_id.to_string(),
-                collateral: 10,
+                collateral: 10.0,
                 validator_net_addr,
             },
         )


### PR DESCRIPTION
This is a PR to address the issue #178. Uses `f64` over `u64` for amount in send value calls.