### PR TITLE
Fix itests for new subnetID and some improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 docs/diagrams/plantuml.jar
 bin
 /lotus
+fx.dot
+testing/itest/logs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,6 +2271,7 @@ dependencies = [
  "ipc-identity",
  "ipc-sdk",
  "log",
+ "num-traits",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ tokio-stream = "0.1.12"
 tokio-graceful-shutdown = "0.12.1"
 tokio-tungstenite = { version = "0.18.0", features = ["native-tls"] }
 derive_builder = "0.12.0"
-num-traits = "0.2.15"
+num-traits = { workspace = true }
 num-derive = "0.3.3"
 env_logger = "0.10.0"
 base64 = { workspace = true }
@@ -61,6 +61,7 @@ tempfile = "3.4.0"
 
 [workspace.dependencies]
 anyhow = "1.0"
+num-traits = "0.2.15"
 base64 = "0.21.0"
 lazy_static = "1.4"
 log = "0.4"

--- a/testing/itest/.env.template
+++ b/testing/itest/.env.template
@@ -1,0 +1,23 @@
+
+# define the following env variable
+# the path to eudico binary path
+export EUDICO_BIN=
+# the ipc root folder that contains all the configs, i.e. ~/.ipc-agent
+export IPC_ROOT_FOLDER=
+# the parent subnet lotus path
+export PARENT_LOTUS_PATH=
+# the parent subnet id
+export PARENT_SUBNET_ID=
+# the name of the subnet
+export SUBNET_NAME=
+
+# start the infra that runs util kill signal
+../../target/release/examples/no_tear_down
+
+# in another terminal, define the following variables
+# the address that performs the funding and release across subnets 
+export FUND_ADDRESS=
+# the ipc agent json rpc url 
+export IPC_AGENT_JSON_RPC_URL=http://localhost:3030/json_rpc
+# child subnet id in string format
+export CHILD_SUBNET_ID_STR=

--- a/testing/itest/Cargo.toml
+++ b/testing/itest/Cargo.toml
@@ -13,6 +13,7 @@ ipc-sdk = { workspace = true }
 log = { workspace = true }
 fvm_shared = { workspace = true }
 serde_json = { workspace = true }
+num-traits = { workspace = true }
 serde = { workspace = true }
 ipc-agent = { path = "../.." }
 ipc-identity = { path = "../../identity" }

--- a/testing/itest/README.md
+++ b/testing/itest/README.md
@@ -7,10 +7,17 @@ when testing subnet checkpoints and cross net messages.
 The `src/infra` contains the process flow for spawn subnet nodes and their validators.
 The `examples` folder contains all the sample scripts to start different configurations and requirements.
 
-To test this, one must first manually start the root net and the ipc agent. Then start the process with:
-```shell
-cargo build --release
+## Requirements
+In order to run these scripts, one must first deploy an IPC rootnet locally, as well as an IPC agent already configured with that network. These integration tests needs access to a `eudico` compiled binary, and assuments that the rootnet is deployed in the local environment, without any kind of virtualization or remote connection.
 
+## Usage
+Once a root net and the IPC agent have been manually configured and spawned. We can compile the itests through:
+```shell
+cargo build --examples --release
+```
+
+We'll then need to configure a set of environmental variables by exporting them manually, or configuring an `.env` file similar to the one shared in `env.template` and `source .env` in the terminal where the tests will be run.
+```shell
 # start the root subnet and ipc agent on your own
 
 # define the following env variable
@@ -24,10 +31,16 @@ export PARENT_LOTUS_PATH=
 export PARENT_SUBNET_ID=
 # the name of the subnet
 export SUBNET_NAME=
+```
 
+We can then run any of the infra scripts available in the `examples` folder. This will deploy the subnet-specific infra for the subnets:
+```shell
 # start the infra that runs util kill signal
 ../../target/release/examples/no_tear_down
+```
 
+Finally, we can run the actual tests by exporting the specific environmental variables required for the test in the corresponding terminal (if not done in previous steps):
+```shell
 # in another terminal, define the following variables
 # the address that performs the funding and release across subnets 
 export FUND_ADDRESS=
@@ -35,7 +48,10 @@ export FUND_ADDRESS=
 export IPC_AGENT_JSON_RPC_URL=http://localhost:3030/json_rpc
 # child subnet id in string format
 export CHILD_SUBNET_ID_STR=
- 
+```
+And running the tests: 
+```shell
 # start the tests with 
 cargo test -p itest --test checkpoint -- --nocapture
 ```
+

--- a/testing/itest/examples/no_create_subnet.rs
+++ b/testing/itest/examples/no_create_subnet.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 use ipc_sdk::subnet_id::SubnetID;
 use itest::infra::SubnetInfra;
-use itest::{infra, DEFAULT_ROOT};
+use itest::{infra, set_network_from_env, DEFAULT_ROOT};
 use std::str::FromStr;
 use std::sync::atomic::AtomicU16;
 use std::sync::Arc;
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() {
+    set_network_from_env();
     run().await.unwrap();
 }
 
@@ -40,7 +41,7 @@ async fn run() -> anyhow::Result<()> {
         eudico_binary_path,
         SubnetID::from_str(&parent_subnet_id_str).unwrap(),
         api_port_sequence,
-        SubnetID::from_str(DEFAULT_ROOT + "/t01002")?,
+        SubnetID::from_str(&(DEFAULT_ROOT.to_owned() + "/t01002"))?,
     );
 
     let mut infra = SubnetInfra::new(config);

--- a/testing/itest/examples/no_tear_down.rs
+++ b/testing/itest/examples/no_tear_down.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 use ipc_sdk::subnet_id::SubnetID;
 use itest::infra::SubnetInfra;
-use itest::{infra, DEFAULT_ROOT};
+use itest::{infra, set_network_from_env, DEFAULT_ROOT};
 use std::str::FromStr;
 use std::sync::atomic::AtomicU16;
 use std::sync::Arc;
@@ -13,6 +13,7 @@ use tokio::signal::unix::{signal, SignalKind};
 
 #[tokio::main]
 async fn main() {
+    set_network_from_env();
     run().await.unwrap();
 }
 

--- a/testing/itest/examples/self_destruct.rs
+++ b/testing/itest/examples/self_destruct.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 use ipc_sdk::subnet_id::SubnetID;
 use itest::infra::SubnetInfra;
-use itest::{infra, DEFAULT_ROOT};
+use itest::{infra, set_network_from_env, DEFAULT_ROOT};
 use std::str::FromStr;
 use std::sync::atomic::AtomicU16;
 use std::sync::Arc;
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 #[tokio::main]
 async fn main() {
+    set_network_from_env();
     run().await.unwrap();
 }
 

--- a/testing/itest/src/infra/mod.rs
+++ b/testing/itest/src/infra/mod.rs
@@ -290,7 +290,7 @@ impl SubnetInfra {
 
         Ok(Subnet {
             id: self.config.id.clone().unwrap(),
-            gateway_addr: Address::from_str("f064")?,
+            gateway_addr: Address::from_str("t064")?,
             network_name: self.config.name.clone(),
             jsonrpc_api_http: format!(
                 "http://127.0.0.1:{:}/rpc/v1",

--- a/testing/itest/src/infra/subnet.rs
+++ b/testing/itest/src/infra/subnet.rs
@@ -7,8 +7,11 @@ use anyhow::{anyhow, Result};
 use ipc_sdk::subnet_id::SubnetID;
 use std::fs;
 use std::fs::File;
+use std::path::Path;
 use std::process::{Child, Command};
 use std::thread::sleep;
+
+const DEFAULT_LOG_DIR: &str = "./logs";
 
 fn node_from_topology(topology: &SubnetConfig) -> SubnetNode {
     SubnetNode::new(
@@ -305,10 +308,16 @@ impl SubnetNode {
 
         let subnet_id = self.subnet_id_cli_string();
 
-        let node_std_out =
-            File::create(format!("./{subnet_id:}_node_{:}.log", self.node.tcp_port))?;
-        let node_std_err =
-            File::create(format!("./{subnet_id:}_node_{:}.err", self.node.tcp_port))?;
+        let base_path = Path::new(DEFAULT_LOG_DIR);
+        fs::create_dir_all(base_path).unwrap();
+        let node_std_out = File::create(Path::join(
+            base_path,
+            format!("./{subnet_id:}_node_{:}.log", self.node.tcp_port),
+        ))?;
+        let node_std_err = File::create(Path::join(
+            base_path,
+            format!("./{subnet_id:}_node_{:}.err", self.node.tcp_port),
+        ))?;
 
         log::info!(
             "spawning node with api: {:}, genesis: {:}, lotus path: {:}",

--- a/testing/itest/src/lib.rs
+++ b/testing/itest/src/lib.rs
@@ -1,6 +1,22 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 
+use fvm_shared::address::{set_current_network, Network};
+use num_traits::cast::FromPrimitive;
+
 pub const DEFAULT_ROOT: &str = "/r31415926";
+
+/// Sets the type of network from an environmental variable.
+/// This is key to set the right network prefixes on string
+/// representation of addresses.
+pub fn set_network_from_env() {
+    let network_raw: u8 = std::env::var("LOTUS_NETWORK")
+        // default to testnet
+        .unwrap_or_else(|_| String::from("1"))
+        .parse()
+        .unwrap();
+    let network = Network::from_u8(network_raw).unwrap();
+    set_current_network(network);
+}
 
 pub mod infra;


### PR DESCRIPTION
## Implementation
This PR: 
- Fixes itests to work with the new implementation of SubnetID. 
- Adds a new `log` directory where logs are persisted and `.gitignore`s unnecessary files

## Testing
In order to test the itests from this PR the branch of the following PR of eudico needs to be used: https://github.com/consensus-shipyard/lotus/pull/187

## Things to improve and high-level feedback.
@cryptoAtwill, as I was tinkering with the code I found a few things that could be improved. Would you mind having a look to see if you can address them yourself (I feel you may be more efficient as you know better this code, but let me know if you want me to do it). 
- When deploying the infra with the scripts, for some reason the resulting configuration doesn't create a new subnet (or at least doesn't appear with list subnets), and there is no way to do any tests. I don't know to what extent it is related with the address of the subnet hardcoded [here](https://github.com/consensus-shipyard/ipc-agent/blob/271f8e90722f28e7b7ac3a80753e39526f85a741/testing/itest/examples/no_create_subnet.rs#L43), what if the subnet address of the subnet created ends up being something else?
- I feel we should spend some time improve the UX of this tool (and I will also contribute to this one). The basic operation of the framework seems great, but the fact that all needs to be done manual (the deployment of the rootnet, configuring the IPC agent, etc.) is a bit of an overhead. As a next step we should include different make rules or scripts that also helps us with this (let me know if you prefer me to include it in a separate issue for future work). 