### PR TITLE
docs to deploy IPC Solidity in calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,14 @@ The `/r31415926` section of the agent's `config.toml` must be updated to connect
 ```toml
 [[subnets]]
 id = "/r31415926"
-gateway_addr = "f064"
 network_name = "root"
-jsonrpc_api_http = "http://127.0.0.1:1234/rpc/v1"
-auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.j94YYOr8_AWhGGHQd0q8JuQVuNhJA017SK9EUkqDOO0"
+
+[subnets.config]
+network_type = "fvm"
 accounts = ["t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq"]
+auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.j94YYOr8_AWhGGHQd0q8JuQVuNhJA017SK9EUkqDOO0"
+gateway_addr = "t064"
+jsonrpc_api_http = "http://127.0.0.1:1234/rpc/v1"
 ```
 
 > 💡 In the current implementation of Spacenet, the gateway is always deployed in the `f064` address. This should be the address always reflected on your config for the gateway. In the future, this will change, and the gateway may be deployed in different addresses.

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ To check if the agent has connected to the rootnet successfully, you can try usi
 
 *Example*:
 ```console
-$ ./bin/ipc-agent wallet new --key-type bls --subnet /r31415926
-2023-03-30T12:01:11Z INFO  ipc_agent::cli::commands::manager::wallet] created new wallet with address WalletNewResponse { address: "t1om5pijjq5dqic4ccnqqrvv6zgzwrlxf6bh2apvi" } in subnet "/r31415926"
+$ ./bin/ipc-agent wallet new -w fvm --key-type bls
+2023-03-30T12:01:11Z INFO  ipc_agent::cli::commands::manager::wallet] created new wallet with address WalletNewResponse { address: "t3u7djutz4kwshntg4abams37ssy63irkfykqimodh4fs7krdst3y5qwcptvexmvic6gs5q6qygerminm2r3la" } in subnet "/r31415926"
 ```
 
 ## Help

--- a/docs/calibration-solidity.md
+++ b/docs/calibration-solidity.md
@@ -1,6 +1,6 @@
 # Deploying an IPC Solidity instance on Calibration
 
-This guide will guide you through deploying IPC over an FEVM-compatible rootnet. Specifically, after this tutorial you'll have IPC deployed over Fileoin's [Calibration testnet](https://docs.filecoin.io/networks/calibration/details/), and you'll be able to deploy new subnets with Calibration as the rootnet.
+This guide will guide you through deploying IPC over an FEVM-compatible rootnet. Specifically, after this tutorial, you'll have IPC deployed over Filecoin's [Calibration testnet](https://docs.filecoin.io/networks/calibration/details/), and you'll be able to deploy new subnets with Calibration as the rootnet.
 
 > TODO: A video walkthrough of this guide is also [available <TODO: We need to record this!](). We still encourage you to try it for yourself!
 

--- a/docs/calibration-solidity.md
+++ b/docs/calibration-solidity.md
@@ -1,0 +1,229 @@
+# Deploying an IPC Solidity instance on Calibration
+
+This guide will guide you through deploying IPC over an FEVM-compatible rootnet. Specifically, after this tutorial you'll have IPC deployed over Fileoin's [Calibration testnet](https://docs.filecoin.io/networks/calibration/details/), and you'll be able to deploy new subnets with Calibration as the rootnet.
+
+> TODO: A video walkthrough of this guide is also [available <TODO: We need to record this!](). We still encourage you to try it for yourself!
+
+## Step 0: Prepare your system
+
+Before jumping right into it, we need to get our system ready for IPC. If you haven't yet tried IPC before, use [Step 0](./quickstart.md#step-0-prepare-your-system) of the [quickstart tutorial](./quickstart.md) to install all the pre-required dependencies in your system.
+
+## Step 1: Get Calibration Funds
+
+In order to deploy over Calibration, and be able to deploy the IPC Solidity contracts, you'll need to get some testnet funds. For that, you can follow [the following detailed guide](https://docs.filecoin.io/smart-contracts/developing-contracts/get-test-tokens/).
+
+At a high-level, the steps that you need to follow are the following (for those already comfortable with Metamask and the Filecoin ecosystem):
+- Create a new Ethereum address with Metamask (or use one of you existing addresses).
+- Go to the [Calibration faucet](https://faucet.calibration.fildev.network/) and send some funds to your address.
+- If you have connected your Metamask to Calibration, you should see in a few seconds the new funds in your wallet (you can follow [this guide](https://docs.filecoin.io/basics/assets/metamask-setup/) to connect your Metamask to Calibration).
+
+>💡 We strongly advise against using an Ethereum address that you are using for mainnet for this. This could lead to unintentional mistakes that you may regret in the future.
+
+With this, we have the funds we need to start deploying IPC.
+
+## Step 2: Deploy IPC Solidity contracts to Calibration
+
+In order to deploy the latest version of the IPC Solidity contracts, you'll need to pull the following repo: 
+```bash
+https://github.com/consensus-shipyard/ipc-solidity-actors
+cd ipc-soldity-actors
+``` 
+Once inside the repo, you'll need to populate the `.env.template` file with the private key of the address you provided with funds in the previous step, and the endpoint of the target network you want to deploy IPC to (in our case Calibration) : 
+```bash
+export PRIVATE_KEY=<your_private_key>
+export RPC_URL=https://api.calibration.node.glif.io/rpc/v1
+```
+> To export your private key from Metamask you can follow [these steps](https://support.metamask.io/hc/en-us/articles/360015289632-How-to-export-an-account-s-private-key)
+
+In your currently open terminal, you'll need to load these variables into your environment so you can deploy the contracts.
+```bash
+source .env.template
+make deploy-ipc NETWORK=calibrationnet
+```
+If the deployment is successful, you should receive an output similar to this one: 
+```
+$ ./ops/deploy.sh localnet
+[*] Deploying libraries
+[*] Output libraries available in /home/workspace/pl/ipc-solidity-actors/scripts/libraries.out
+[*] Populating deploy-gateway script
+[*] Gateway script in /home/workspace/pl/ipc-solidity-actors/scripts/deploy-gateway.ts
+[*] Gateway deployed: 
+{ Gateway: '0x2bA26fe8EB6b5C8488132900F00d853ca840F2FB' }
+[*] Output gateway address in /home/workspace/pl/ipc-solidity-actors/scripts/gateway.out
+[*] Populating deploy-registry script
+[*] Registry script in /home/workspace/pl/ipc-solidity-actors/scripts/deploy-registry.ts
+No need to generate any newer typings.
+Nothing to compile
+No need to generate any newer typings.
+Deploying contracts with account: 0x6BE1Ccf648c74800380d0520D797a170c808b624 and balance: 2999143347078092235924
+registry contract deployed to: 0x221485C0948dAa7C8dC1bCbcf813684C5EC1ecED
+[*] IPC actors successfully deployed
+```
+Keep the addresses of the gateway and the registry contracts deployed, as you will need them to configure the IPC agent in the next step.
+
+>💡If instead of deploying IPC Solidity in Calibration, you want to test them in Spacenet or a local network, the only thing that you need to do is to configure the `RPC_URL` of your `.env` to point to the corresponding network's RPC endpoint, and `make deploy-ipc NETWORK=localnet`.
+
+## Step 3: Configure IPC Agent.
+
+After deploying the IPC contracts, we come out of the contracts repo (i.e. where we cloned the `ipc-agent` repo). Let's now deploy and configure our IPC agent. 
+- Compile the IPC agent
+```bash
+cd ipc-agent
+make build
+cd ..
+```
+- We then to initialize a config template and configure it to connect to our IPC instance in Calibration.
+```toml
+[server]
+json_rpc_address = "0.0.0.0:3030"
+
+[[subnets]]
+id = "/r314159"
+network_name = "calibration"
+
+[subnets.config]
+accounts = ["0x6BE1Ccf648c74800380d0520D797a170c808b624"]
+gateway_addr = "0x2bA26fe8EB6b5C8488132900F00d853ca840F2FB"
+network_type = "fevm"
+private_key = <your_private_key>
+provider_http = "https://api.calibration.node.glif.io/rpc/v1"
+registry_addr = "0x221485C0948dAa7C8dC1bCbcf813684C5EC1ecED"
+
+```
+
+In `accounts` you should include the address that you want to use to interact with IPC (remember to have some funds in this address)
+, and in `private_key` its corresponding private key. The gateway and registry addresses should be the ones we received after deploying our IPC instance (in the previous step). Finally, the `provider_http` should be our endpoint to calibration (or our rootnet).
+
+>💡 Remember that the subnetID depends on the chainID of that network. Thus, when you are configuring your IPC agent to connect to an instance deployed over localnet or spacenet, their rootnet ID will be `/r31415926`, while the one for Calibration is `/r314159`.
+
+- Finally, we start the IPC agent:
+```bash
+./ipc-agent/bin/ipc-agent daemon 
+```
+## Step 4: Create a child subnet
+
+* [**In a new session**] The next step is to create a subnet under `/r314159` in calibration
+```bash
+./ipc-agent/bin/ipc-agent subnet create --parent /r314159 --name andromeda --min-validator-stake 1 --min-validators 2 --bottomup-check-period 30 --topdown-check-period 30
+```
+* Make a note of the address of the subnet you created (`/r314159/<SUBNET_ID>`)
+
+
+## Step 5: Create and export validator wallets
+
+Although we set a minimum of 2 active validators in the previous, we'll deploy 3 validators to add some redundancy. These will become the worker addresses of the validators in the child subnet.
+
+* First, we'll need to create a wallet for each validator
+```bash
+./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1
+./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1
+./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1
+```
+* Export each wallet (WALLET_1, WALLET_2, and WALLET_3) by substituting their addresses below
+```bash
+./ipc-agent/bin/ipc-agent wallet export --address <WALLET_1> --output ~/.ipc-agent/worker-wallet1.key
+./ipc-agent/bin/ipc-agent wallet export --address <WALLET_2> --output ~/.ipc-agent/worker-wallet2.key
+./ipc-agent/bin/ipc-agent wallet export --address <WALLET_3> --output ~/.ipc-agent/worker-wallet3.key
+```
+
+>💡 Mir validators do not support the use of Ethereum addresses to create new blocks. This is why since the deployment of IPC Solidity instances, we introduced the concept of `worker_addresses`, which is the address use by validators to create new blocks. Validators have an `owner_address`, used to join a network, and they can optionally include a `worker_address`. Setting a `worker_address` is mandatory when interacting with an FEVM-based parent and not required for FVM-based.
+
+We will also have to create two new Ethereum addresses to be used as the owner addresses to join the subnet in the FEVM-based IPC instance from calibration. You can do this directly using Metamask (or following [this guide](https://docs.filecoin.io/basics/assets/metamask-setup/)).
+
+## Step 6: Deploy the infrastructure
+
+We can deploy the subnet nodes. Note that each node should be importing a different worker wallet key for their validator, and should be exposing different ports. If these ports are unavailable in your system, please pick different ones.
+
+* Deploy and run a container for each validator, importing the corresponding wallet keys
+```bash
+./ipc-agent/bin/ipc-infra/run-subnet-docker.sh 1251 1351 /r314159/<SUBNET_ID> ~/.ipc-agent/worker-wallet1.key
+./ipc-agent/bin/ipc-infra/run-subnet-docker.sh 1252 1352 /r314159/<SUBNET_ID> ~/.ipc-agent/worker-wallet2.key
+./ipc-agent/bin/ipc-infra/run-subnet-docker.sh 1253 1353 /r314159/<SUBNET_ID> ~/.ipc-agent/worker-wallet3.key
+```
+* If the deployment is successful, each of these nodes should return the following output at the end of their logs. Save the information for the next step.
+```
+>>> Subnet /r314159/<SUBNET_ID> daemon running in container: <CONTAINER_ID_#> (friendly name: <CONTAINER_NAME_#>)
+>>> Token to /r314159/<SUBNET_ID> daemon: <AUTH_TOKEN_#>
+>>> Default wallet: <WALLET_#>
+>>> Subnet validator info:
+<VALIDATOR_ADDR_#>
+>>> API listening in host port <PORT_#>
+>>> Validator listening in host port <VALIDATOR_PORT_#>
+```
+
+## Step 7: Configure the IPC agent
+
+For ease of use in the management of the validators the IPC Agent will act on behalf of all validators.
+
+* Edit the IPC agent configuration `config.toml`
+```bash
+nano ~/.ipc-agent/config.toml
+```
+* Append the new subnet to the configuration
+```toml
+[[subnets]]
+id = "/r314159/t410fns7xiomya2zq5nsejjphoywktlwvkkdtgng7ceq"
+network_name = "andromeda"
+
+[subnets.config]
+gateway_addr = "t064"
+accounts = ["<WALLET_1>", "<WALLET_2>", "<WALLET_3>"]
+jsonrpc_api_http = "http://127.0.0.1:1251/rpc/v1"
+auth_token = "<AUTH_TOKEN_1>"
+network_type = "fvm"
+```
+* Reload the config
+```bash 
+./ipc-agent/bin/ipc-agent config reload
+```
+
+## Step 8: Join the subnet 
+
+All the infrastructure for the subnet is now deployed, and we can join our validators to the subnet. For this, we need to send a `join` command from each of our validators from their validator owner addresses providing the validators multiaddress. 
+
+* Join the subnet with each validator
+```bash
+./ipc-agent/bin/ipc-agent subnet join --subnet /r314159/<SUBNET_ID> --collateral 1 --validator-net-addr <VALIDATOR_ADDR_1> --worker-addr <WALLET_1> 
+./ipc-agent/bin/ipc-agent subnet join --subnet /r314159/<SUBNET_ID> --collateral 1 --validator-net-addr <VALIDATOR_ADDR_2> --worker-addr <WALLET_2>
+./ipc-agent/bin/ipc-agent subnet join --subnet /r314159/<SUBNET_ID> --collateral 1 --validator-net-addr <VALIDATOR_ADDR_3> --worker-addr <WALLET_3>
+```
+>💡 We currently do not support the use of `from` for Ethereum addresses ([see issue](https://github.com/consensus-shipyard/ipc-agent/issues/244)), in order to send a `join` from different owner Ethreum accounts, you'll need to set the `private_key` from each account of a validator address in `~/.ipc-agent/config.toml` and `./ipc-agent/bin/ipc-agent config reload` before every join to use a different owner key to join the subnet for each worker key.
+
+## Step 9: Start validating! 
+
+We have everything in place now to start validating. Run the following script for each of the validators [**each in a new session**], passing the container names:
+```bash
+./ipc-agent/bin/ipc-infra/mine-subnet.sh <CONTAINER_NAME_1> 
+./ipc-agent/bin/ipc-infra/mine-subnet.sh <CONTAINER_NAME_2> 
+./ipc-agent/bin/ipc-infra/mine-subnet.sh <CONTAINER_NAME_3> 
+```
+
+>💡 When starting mining and reloading the config to include the new subnet, you can sometimes get errors in the agent logs saying that the checkpoint manager couldn't be spawned successfully because the on-chain ID of the validator couldn't be change. This is because the subnet hasn't been fully initialized yet. You can `./ipc-agent/bin/ipc-agent config reload` to re-spawn the checkpoint manager and fix the error.
+
+## Step 10: Cross-net messages
+
+We are now going to test the use of cross-net messages between the parent and the child subnet.
+- We will first create a new wallet and send a some funds to it in the child subnet.
+```bash
+./ipc-agent/bin/ipc-agent wallet new --key-type=secp256k1
+
+./ipc-agent/bin/ipc-agent cross-msg fund --subnet=<SUBNET_ID> --to=<NEW_WALLET> <AMOUNT>
+```
+The funds will be propagated in the next top-down checkpoint, you can see the last top-down checkpoint that was committed to see if your funds have already arrived using:
+```bash
+./bin/ipc-agent checkpoint last-topdown --subnet=<SUBNET_ID>
+```
+The epoch of this command should be higher or equal to the epoch in the output of `fund`.
+- To release funds from a subnet, you can run a `release` command from any balance with funds from the subnet (bear in mind that by default, the address used to perform the operation is the one set in your agen't config):
+```bash
+./ipc-agent/bin/ipc-agent cross-msg release --subnet=<SUBNET_ID> --to=<NEW_WALLET> <AMOUNT>
+```
+- To see if the funds where successfully sent to any of your subnet run after any of the above cross-net messages you can run: 
+```bash
+./bin/ipc-agent wallet balances --subnet=<SUBNET_ID>
+```
+
+
+## Step 10: What now?
+* If something went wrong, please have a look at the [README](https://github.com/consensus-shipyard/ipc-agent). If it doesn't help, please join us in #ipc-help. In either case, let us know your experience!
+* Please note that to repeat this guide or spawn a new subnet, you may need to change the parameters or reset your system.

--- a/docs/evm-usage.md
+++ b/docs/evm-usage.md
@@ -1,0 +1,47 @@
+# IPC Agent EVM Support
+
+## Key management
+The IPC agent has internally and EVM wallet that it uses to sign transactions and interact with IPC on behalf of specific addresses. Some of the features available for EVM addresses through the EVM are: 
+* Creating new Ethereum addresses
+```bash
+./bin/ipc-agent wallet new -w evm
+
+# Sample execution
+./bin/ipc-agent wallet new -w evm
+
+[2023-07-12T10:58:37Z INFO  ipc_agent::cli::commands::wallet::new] created new wallet with address WalletNewResponse { address: "0x6972968294f71daba16939f77dfd738525796a63" }
+```
+
+* Exporting a key stored in the IPC agent. 
+```bash
+./bin/ipc-agent wallet export -w evm -a <EVM-ADDRESS> -o <OUTPUT_FILE>
+
+# Sample execution
+./bin/ipc-agent wallet export -w evm -a 0x92e2dd319dae2f5698ef5cbde610ad611983de0d -o ~/.ipc-agent/evm-wallet.key
+
+[2023-07-12T11:00:01Z INFO  ipc_agent::cli::commands::wallet::export] exported new wallet with address "0x92e2dd319dae2f5698ef5cbde610ad611983de0d" in file "~/.ipc-agent/evm-wallet.key"
+```
+
+* Importing a key from a file
+```bash
+./bin/ipc-agent wallet import -w evm --path=<INPUT_FILE_WITH_KEY>
+
+# Sample execution
+./bin/ipc-agent wallet import -w evm --path=~/.ipc-agent/evm-wallet.key
+[2023-07-12T11:00:59Z INFO  ipc_agent::cli::commands::wallet::import] imported wallet with address "0x92e2…de0d"
+```
+
+> 💡 The format expected to import new EVM keys is the following:
+> ```
+> {"address":<EVM-ADDRESS>,"private_key":<PRIVATE_KEY>}
+> ```
+> You can always create this file manually to import some address into the agent that you have exported from some other tool with an alternative format.
+
+* Importing an identity directly from its private key
+```bash
+./bin/ipc-agent wallet import -w evm --private-key <PRIVATE_KEY>
+
+# Sample execution
+./bin/ipc-agent wallet import -w evm --private-key=0x405f50458008edd6e2eb2efc3bf34846db1d6689b89fe1a9f9ccfe7f6e301d8d
+
+[2023-07-12T11:00:59Z INFO  ipc_agent::cli::commands::wallet::import] imported wallet with address "0x92e2…de0d"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -104,7 +104,7 @@ jsonrpc_api_http = "http://127.0.0.1:1234/rpc/v1"
 
 * Create a new wallet in your agent
 ```bash
-./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1
+./ipc-agent/bin/ipc-agent wallet new -w fvm --key-type secp256k1
 ```
 
 * Add your new wallet address in the accounts field of your config:
@@ -139,15 +139,15 @@ Although we set a minimum of 2 active validators in the previous, we'll deploy 3
 
 * First, we'll need to create a wallet for each validator
 ```bash
-./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1
-./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1
-./ipc-agent/bin/ipc-agent wallet new --key-type secp256k1
+./ipc-agent/bin/ipc-agent wallet new -w fvm --key-type secp256k1
+./ipc-agent/bin/ipc-agent wallet new -w fvm --key-type secp256k1
+./ipc-agent/bin/ipc-agent wallet new -w fvm --key-type secp256k1
 ```
 * Export each wallet (WALLET_1, WALLET_2, and WALLET_3) by substituting their addresses below
 ```bash
-./ipc-agent/bin/ipc-agent wallet export --address <WALLET_1> --output ~/.ipc-agent/wallet1.key
-./ipc-agent/bin/ipc-agent wallet export --address <WALLET_2> --output ~/.ipc-agent/wallet2.key
-./ipc-agent/bin/ipc-agent wallet export --address <WALLET_3> --output ~/.ipc-agent/wallet3.key
+./ipc-agent/bin/ipc-agent wallet export -w fvm --address <WALLET_1> --output ~/.ipc-agent/wallet1.key
+./ipc-agent/bin/ipc-agent wallet export -w fvm --address <WALLET_2> --output ~/.ipc-agent/wallet2.key
+./ipc-agent/bin/ipc-agent wallet export -w fvm --address <WALLET_3> --output ~/.ipc-agent/wallet3.key
 ```
 * We also need to fund the wallets with enough collateral to; we'll send the funds from our default wallet 
 ```bash

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -88,11 +88,14 @@ json_rpc_address = "0.0.0.0:3030"
 
 [[subnets]]
 id = "/r31415926"
-gateway_addr = "t064"
-network_name = "andromeda"
-jsonrpc_api_http = "http://127.0.0.1:1234/rpc/v1"
-auth_token = "<AUTH_TOKEN_0>"
+network_name = "root"
+
+[subnets.config]
+network_type = "fvm"
 accounts = []
+auth_token = "<AUTH_TOKEN_0>"
+gateway_addr = "t064"
+jsonrpc_api_http = "http://127.0.0.1:1234/rpc/v1"
 ```
 * [**In a new session**] Start your IPC Agent
 ```bash
@@ -179,6 +182,7 @@ We can deploy the subnet nodes. Note that each node should be importing a differ
 ## Step 7: Configure the IPC agent
 
 For ease of use, we'll import the remaining keys into the first validator, via which the IPC Agent will act on behalf of all.
+
 * Edit the IPC agent configuration `config.toml`
 ```bash
 nano ~/.ipc-agent/config.toml
@@ -187,11 +191,14 @@ nano ~/.ipc-agent/config.toml
 ```toml
 [[subnets]]
 id = "/r31415926/<SUBNET_ID>"
-gateway_addr = "t064"
 network_name = "andromeda"
-jsonrpc_api_http = "http://127.0.0.1:1251/rpc/v1"
-auth_token = "<AUTH_TOKEN_1>"
+
+[subnets.config]
+network_type = "fvm"
 accounts = ["<WALLET_1>", "<WALLET_2>", "<WALLET_3>"]
+auth_token = "<AUTH_TOKEN_1>"
+gateway_addr = "t064"
+jsonrpc_api_http = "http://127.0.0.1:1251/rpc/v1"
 ```
 * Reload the config
 ```bash 

--- a/docs/subnet.md
+++ b/docs/subnet.md
@@ -12,7 +12,7 @@ We provide instructions for running both a [simple single-validator subnet](#run
 
 In order to run a validator in a subnet, we'll need a set of keys to handle that validator. To export the validator key from your agent you need to run: 
 ```bash
-./ipc-agent/bin/ipc-agent wallet export --address <address-to-export> --output <output file>
+./ipc-agent/bin/ipc-agent wallet export -w fvm --address <address-to-export> --output <output file>
 ```
 
 If for some reason, you want to use for your validator a set of keys that are not managed by the IPC agent, and are held in a raw Eudico node of another network, you can export the wallet key into a file (like the wallet address we are using in the rootnet), with the following Lotus command:
@@ -38,7 +38,7 @@ $ docker exec -it ipc_root_1234 eudico wallet export --lotus-json t1cp4q4lqsdhob
 ### Importing wallet keys
 Your agent handles the keys for all of your addresses in IPC and is responsible for signing the transactions to the different networks. To import a key to the agent you can use: 
 ```bash
-`./ipc-agent/bin/ipc-agent wallet import --path <wallet-key-file-path>`
+`./ipc-agent/bin/ipc-agent wallet import -w fvm --path <wallet-key-file-path>`
 ```
 
 The only operation that requres importing the keys into your raw Eudico node is when running a subnet validator. Subnet validators need to hold the validator keys in their wallets in order to be able to sign new blocks. You may use the following commands to import a wallet directly into the raw subnet node of your validator: 
@@ -149,7 +149,7 @@ The mining process is currently run in the foreground in interactive mode. Consi
 
 In this section, we will deploy a subnet where the IPC agent is responsible for handling more than one validator in the subnet. We are going to deploy a subnet with 3 validators. The first thing we'll need to do is create a new wallet for every validator we want to run. We can do this directly through the agent with the following command (3x):
 ```bash
-./bin/ipc-agent wallet new --key-type secp256k1 --subnet /r31415926
+./bin/ipc-agent wallet new -w fvm --key-type secp256k1 --subnet /r31415926
 ```
 
 We also need to provide with some funds our wallets so they can put collateral to join the subnet. According to the rootnet you are connected to, you may need to get some funds from the faucet, or send some from your main wallet. Funds can be sent from your main wallet also through the agent with (3x, adjusting `target-wallet` for each): 

--- a/docs/subnet.md
+++ b/docs/subnet.md
@@ -109,11 +109,14 @@ The end of the log of the execution of this script provides a bit more of inform
 ```toml
 [[subnets]]
 id = "/r31415926/t2xwzbdu7z5sam6hc57xxwkctciuaz7oe5omipwbq"
-gateway_addr = "f064"
 network_name = "test"
-jsonrpc_api_http = "http://127.0.0.1:1250/rpc/v1"
-auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.TnoDqZJ1fqdkr_oCHFEXvdwU6kYR7Va_ALyEuoPnksA"
+
+[subnets.config]
+network_type = "fvm"
 accounts = ["t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq"]
+auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.TnoDqZJ1fqdkr_oCHFEXvdwU6kYR7Va_ALyEuoPnksA"
+gateway_addr = "t064"
+jsonrpc_api_http = "http://127.0.0.1:1250/rpc/v1"
 ```
 > 💡 Remember to run `./bin/ipc-agent config reload` for changes in the config of the agent to be picked up by the daemon.
 
@@ -192,14 +195,19 @@ To configure the agent for its use with all the validators, we need to connect t
 
 Here's an example of the configuration connecting to the RPC of the first validator, and configuring all the wallets for the validators in the subnet.
 ```toml
+
 [[subnets]]
 id = "/r31415926/t2xwzbdu7z5sam6hc57xxwkctciuaz7oe5omipwbq"
-gateway_addr = "f064"
 network_name = "test"
-jsonrpc_api_http = "http://127.0.0.1:1240/rpc/v1"
-auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.JTiumQwFIutkTb0gUC5JWTATs-lUvDaopEDE0ewgzLk"
+
+[subnets.config]
+network_type = "fvm"
 accounts = ["t1ivy6mo2ofxw4fdmft22nel66w63fb7cuyslm4cy", "t1cp4q4lqsdhob23ysywffg2tvbmar5cshia4rweq", "t1nv5jrdxk4ljzndaecfjgmu35k6iz54pkufktvua"]
+auth_token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJBbGxvdyI6WyJyZWFkIiwid3JpdGUiLCJzaWduIiwiYWRtaW4iXX0.JTiumQwFIutkTb0gUC5JWTATs-lUvDaopEDE0ewgzLk"
+gateway_addr = "t064"
+jsonrpc_api_http = "http://127.0.0.1:1240/rpc/v1"
 ```
+
 Remember to run `./bin/ipc-agent config reload` for your agent to pick up the latest changes for the config.
 
 ### Joining the subnet

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -64,7 +64,7 @@ Complex behavior can be implemented using these primitives: sending value to a u
 ### Fund
 Funding a subnet can be performed by using the following command:
 ```bash
-./bin/ipc-agent cross-msg fund --subnet <subnet-id> [--from <from-addr>] <amount>
+./bin/ipc-agent cross-msg fund --subnet <subnet-id> [--from <from-addr>] [--to <to-addr>] <amount>
 ```
 ```console
 # Example execution
@@ -72,18 +72,30 @@ $ ./bin/ipc-agent cross-msg fund --subnet /r31415926/t2xwzbdu7z5sam6hc57xxwkctci
 ```
 This command includes the cross-net message into the next top-down checkpoint after the current epoch. Once the top-down checkpoint is committed, you should see the funds in your account of the child subnet.
 
+Alternatively, we can pass an additional parameter to send the funds to a specific address in the child subnet
+
+```console
+# Example execution
+$ ./bin/ipc-agent cross-msg fund --subnet /r31415926/t2xwzbdu7z5sam6hc57xxwkctciuaz7oe5omipwbq --to=t17o2heqfzxfvtlopxilwoofte3akece2tgps7uny 100
+```
 >💡 Top-down checkpoints are not used to anchor the security of the parent into the child (as is the case for bottom-up checkpoints). They just include information of the top-down messages that need to be executed in the child subnet, and are a way for validators in the subnet to reach consensus on the finality on their parent.
 
 ### Release
 In order to release funds from a subnet, your account must hold enough funds inside it. Releasing funds to the parent subnet can be permformed with the following comand:
 ```bash
-./bin/ipc-agent cross-msg release --subnet <subnet-id> [--from <from-addr>] <amount>
+./bin/ipc-agent cross-msg release --subnet <subnet-id> [--from <from-addr>] [--to <to-addr>] <amount>
 ```
 ```console
 # Example execution
 $ ./bin/ipc-agent cross-msg release --subnet=/r31415926/t2xwzbdu7z5sam6hc57xxwkctciuaz7oe5omipwbq 100
 ```
 This command includes the cross-net message into a bottom-up checkpoint after the current epoch. Once the bottom-up checkpoint is committed, you should see the funds in your account in the parent. 
+
+Alternatively, we can pass an additional parameter to release the funds to a specific address in the parent subnet
+
+```console
+# Example execution
+$ ./bin/ipc-agent cross-msg release --subnet /r31415926/t2xwzbdu7z5sam6hc57xxwkctciuaz7oe5omipwbq --to=t17o2heqfzxfvtlopxilwoofte3akece2tgps7uny 100
 
 
 ## Listing checkpoints from a subnet


### PR DESCRIPTION
This PR adds a quickstart guide to deploy IPC solidity contracts to Calibration. Additionally, it updates the config and cross-net message primitives with all the changes to be included in the next release.