### PR TITLE
increase timeout to support mainnet/calibration

### DIFF
--- a/src/jsonrpc/mod.rs
+++ b/src/jsonrpc/mod.rs
@@ -25,7 +25,9 @@ mod tests;
 
 const DEFAULT_JSON_RPC_VERSION: &str = "2.0";
 const DEFAULT_JSON_RPC_ID: u8 = 1;
-const DEFAULT_REQ_TIMEOUT: Duration = Duration::from_secs(30);
+/// Request timeout of the RPC client. It should be enough to accommodate
+/// the time required to validate transaction on-chain.
+const DEFAULT_REQ_TIMEOUT: Duration = Duration::from_secs(100);
 
 /// A convenience constant that represents empty params in a JSON-RPC request.
 pub const NO_PARAMS: Value = json!([]);


### PR DESCRIPTION
The 30s timeout we had wasn't enough to accommodate the delay of sending a transaction to calibration and mainnet.