### PR TITLE
Fix keystore after integration testing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ bytes = "1.4.0"
 serde_bytes = "0.11.9"
 clap = { version = "4.1.4", features = ["env", "derive"] }
 thiserror = { workspace = true }
+hex = { workspace = true }
 serde_tuple = "0.5.0"
 zeroize = "1.6.0"
 

--- a/identity/src/evm/mod.rs
+++ b/identity/src/evm/mod.rs
@@ -12,6 +12,8 @@ use zeroize::Zeroize;
 
 pub use crate::evm::persistent::PersistentKeyStore;
 
+pub const DEFAULT_KEYSTORE_NAME: &str = "evm_keystore.json";
+
 /// The key store trait for different evm key store
 pub trait KeyStore {
     /// The type of the key that is stored

--- a/identity/src/lib.rs
+++ b/identity/src/lib.rs
@@ -6,5 +6,7 @@
 mod evm;
 mod fvm;
 
-pub use crate::evm::{KeyInfo as EvmKeyInfo, KeyStore as EvmKeyStore, PersistentKeyStore};
+pub use crate::evm::{
+    KeyInfo as EvmKeyInfo, KeyStore as EvmKeyStore, PersistentKeyStore, DEFAULT_KEYSTORE_NAME,
+};
 pub use crate::fvm::*;

--- a/src/checkpoint/fevm_fvm/topdown.rs
+++ b/src/checkpoint/fevm_fvm/topdown.rs
@@ -78,7 +78,7 @@ impl<P: EthManager + Send + Sync, C: LotusClient + Send + Sync> CheckpointManage
     for TopDownCheckpointManager<P, C>
 {
     fn target_subnet(&self) -> &Subnet {
-        &self.child
+        &self.parent
     }
 
     fn parent_subnet(&self) -> &Subnet {

--- a/src/checkpoint/fevm_fvm/topdown.rs
+++ b/src/checkpoint/fevm_fvm/topdown.rs
@@ -78,7 +78,7 @@ impl<P: EthManager + Send + Sync, C: LotusClient + Send + Sync> CheckpointManage
     for TopDownCheckpointManager<P, C>
 {
     fn target_subnet(&self) -> &Subnet {
-        &self.parent
+        &self.child
     }
 
     fn parent_subnet(&self) -> &Subnet {

--- a/src/manager/evm/manager.rs
+++ b/src/manager/evm/manager.rs
@@ -95,7 +95,10 @@ impl SubnetManager for EthSubnetManager {
 
         log::info!("creating subnet on evm with params: {params:?}");
 
-        let signer = self.get_signer(&payload_to_evm_address(from.payload())?)?;
+        let evm_from = payload_to_evm_address(from.payload())?;
+        log::debug!("original from address: {from:?}, evm: {evm_from:?}");
+
+        let signer = self.get_signer(&evm_from)?;
         let registry_contract =
             SubnetRegistry::new(self.ipc_contract_info.registry_addr, Arc::new(signer));
 

--- a/src/server/handlers/config.rs
+++ b/src/server/handlers/config.rs
@@ -57,7 +57,7 @@ pub fn new_evm_keystore_from_config(
     let repo_str = config.get_config_repo();
     if let Some(repo_str) = repo_str {
         let repo = Path::new(&repo_str).join(DEFAULT_KEYSTORE_NAME);
-        PersistentKeyStore::new(repo.into())
+        PersistentKeyStore::new(repo)
             .map_err(|e| anyhow!("Failed to create evm keystore: {}", e))
     } else {
         Err(anyhow!("No keystore repo found in config"))

--- a/src/server/handlers/config.rs
+++ b/src/server/handlers/config.rs
@@ -57,8 +57,7 @@ pub fn new_evm_keystore_from_config(
     let repo_str = config.get_config_repo();
     if let Some(repo_str) = repo_str {
         let repo = Path::new(&repo_str).join(DEFAULT_KEYSTORE_NAME);
-        PersistentKeyStore::new(repo)
-            .map_err(|e| anyhow!("Failed to create evm keystore: {}", e))
+        PersistentKeyStore::new(repo).map_err(|e| anyhow!("Failed to create evm keystore: {}", e))
     } else {
         Err(anyhow!("No keystore repo found in config"))
     }

--- a/src/server/handlers/config.rs
+++ b/src/server/handlers/config.rs
@@ -6,8 +6,8 @@ use crate::config::ReloadableConfig;
 use crate::server::JsonRPCRequestHandler;
 use anyhow::anyhow;
 use async_trait::async_trait;
-use ipc_identity::PersistentKeyStore;
 use ipc_identity::{KeyStore, KeyStoreConfig, KEYSTORE_NAME};
+use ipc_identity::{PersistentKeyStore, DEFAULT_KEYSTORE_NAME};
 use serde::{Deserialize, Serialize};
 use std::{path::Path, sync::Arc};
 
@@ -56,7 +56,7 @@ pub fn new_evm_keystore_from_config(
 ) -> anyhow::Result<PersistentKeyStore<ethers::types::Address>> {
     let repo_str = config.get_config_repo();
     if let Some(repo_str) = repo_str {
-        let repo = Path::new(&repo_str);
+        let repo = Path::new(&repo_str).join(DEFAULT_KEYSTORE_NAME);
         PersistentKeyStore::new(repo.into())
             .map_err(|e| anyhow!("Failed to create evm keystore: {}", e))
     } else {

--- a/src/server/handlers/manager/create.rs
+++ b/src/server/handlers/manager/create.rs
@@ -71,7 +71,7 @@ impl JsonRPCRequestHandler for CreateSubnetHandler {
         };
 
         let from = parse_from(subnet_config, request.from)?;
-        log::debug!("conn: {:?}", conn.subnet());
+        log::debug!("conn: {:?}, from: {from:?}", conn.subnet());
 
         let created_subnet_addr = conn
             .manager()

--- a/src/server/handlers/wallet/import.rs
+++ b/src/server/handlers/wallet/import.rs
@@ -30,7 +30,7 @@ pub struct FvmImportParams {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct EvmImportParams {
-    /// Base64 encoded private key string
+    /// Hex encoded private key string
     pub private_key: String,
 }
 
@@ -93,7 +93,11 @@ impl WalletImportHandler {
     fn import_evm(&self, request: &EvmImportParams) -> anyhow::Result<WalletImportResponse> {
         let mut keystore = self.evm_keystore.write().unwrap();
 
-        let private_key = base64::engine::general_purpose::STANDARD.decode(&request.private_key)?;
+        let private_key = if !request.private_key.starts_with("0x") {
+            hex::decode(&request.private_key)?
+        } else {
+            hex::decode(&request.private_key.as_str()[2..])?
+        };
         let addr = keystore.put(EvmKeyInfo::new(private_key))?;
 
         Ok(WalletImportResponse {

--- a/testing/itest/src/infra/mod.rs
+++ b/testing/itest/src/infra/mod.rs
@@ -139,7 +139,7 @@ impl SubnetInfra {
 
         let actor_addr = util::create_subnet(
             self.config.ipc_agent_url(),
-            self.config.parent_wallet_address.clone(),
+            Some(self.config.parent_wallet_address.clone()),
             parent,
             self.config.name.clone(),
             self.config.number_of_nodes as u64,

--- a/testing/itest/src/infra/mod.rs
+++ b/testing/itest/src/infra/mod.rs
@@ -139,7 +139,7 @@ impl SubnetInfra {
 
         let actor_addr = util::create_subnet(
             self.config.ipc_agent_url(),
-            Some(self.config.parent_wallet_address.clone()),
+            None,
             parent,
             self.config.name.clone(),
             self.config.number_of_nodes as u64,

--- a/testing/itest/src/infra/subnet.rs
+++ b/testing/itest/src/infra/subnet.rs
@@ -366,6 +366,7 @@ impl SubnetNode {
         util::join_subnet(
             self.ipc_agent_url.clone(),
             None,
+            Some(self.wallet_address.clone().unwrap()),
             self.id.to_string(),
             DEFAULT_MIN_STAKE,
             self.validator.net_addr.clone().unwrap(),

--- a/testing/itest/src/infra/subnet.rs
+++ b/testing/itest/src/infra/subnet.rs
@@ -365,7 +365,7 @@ impl SubnetNode {
     pub async fn join_subnet(&self) -> Result<()> {
         util::join_subnet(
             self.ipc_agent_url.clone(),
-            self.wallet_address.clone().unwrap(),
+            None,
             self.id.to_string(),
             DEFAULT_MIN_STAKE,
             self.validator.net_addr.clone().unwrap(),

--- a/testing/itest/src/infra/util.rs
+++ b/testing/itest/src/infra/util.rs
@@ -42,7 +42,7 @@ pub async fn create_subnet(
 /// Join the subnet
 pub async fn join_subnet(
     ipc_agent_url: String,
-    from: String,
+    from: Some(String),
     subnet: String,
     collateral: f64,
     validator_net_addr: String,
@@ -50,7 +50,7 @@ pub async fn join_subnet(
     let client = client_from_url(ipc_agent_url)?;
     let params = JoinSubnetParams {
         subnet,
-        from: Some(from),
+        from,
         collateral,
         validator_net_addr,
         worker_addr: None,

--- a/testing/itest/src/infra/util.rs
+++ b/testing/itest/src/infra/util.rs
@@ -21,14 +21,14 @@ fn client_from_url(url: String) -> anyhow::Result<IpcAgentClient<JsonRpcClientIm
 /// Create a new subnet in the actor
 pub async fn create_subnet(
     ipc_agent_url: String,
-    from: String,
+    from: Option<String>,
     parent: String,
     name: String,
     min_validators: u64,
 ) -> anyhow::Result<String> {
     let client = client_from_url(ipc_agent_url)?;
     let params = CreateSubnetParams {
-        from: Some(from),
+        from,
         parent,
         name,
         min_validator_stake: DEFAULT_MIN_STAKE,

--- a/testing/itest/src/infra/util.rs
+++ b/testing/itest/src/infra/util.rs
@@ -43,6 +43,7 @@ pub async fn create_subnet(
 pub async fn join_subnet(
     ipc_agent_url: String,
     from: Option<String>,
+    worker_addr: Option<String>,
     subnet: String,
     collateral: f64,
     validator_net_addr: String,
@@ -53,7 +54,7 @@ pub async fn join_subnet(
         from,
         collateral,
         validator_net_addr,
-        worker_addr: None,
+        worker_addr,
     };
     client.join_subnet(params).await
 }

--- a/testing/itest/src/infra/util.rs
+++ b/testing/itest/src/infra/util.rs
@@ -42,7 +42,7 @@ pub async fn create_subnet(
 /// Join the subnet
 pub async fn join_subnet(
     ipc_agent_url: String,
-    from: Some(String),
+    from: Option<String>,
     subnet: String,
     collateral: f64,
     validator_net_addr: String,


### PR DESCRIPTION
This PR contains some adhoc fixes after performing integration testing, key changes:
1. Update `itest` crate to accommodate evm keystore changes
2. Set default file name for evm keystore