### PR TITLE
add send_value evm support

### DIFF
--- a/src/manager/evm/conversion.rs
+++ b/src/manager/evm/conversion.rs
@@ -389,7 +389,7 @@ mod tests {
     #[test]
     fn test_amount_conversion() {
         let v = BigInt::from_str("100000000000000").unwrap();
-        let fil_amount = TokenAmount::from_atto(v.clone());
+        let fil_amount = TokenAmount::from_atto(v);
 
         let eth_amount = fil_to_eth_amount(&fil_amount).unwrap();
         let test_amount = eth_to_fil_amount(&eth_amount).unwrap();

--- a/src/manager/evm/conversion.rs
+++ b/src/manager/evm/conversion.rs
@@ -349,9 +349,13 @@ impl TryFrom<crate::manager::evm::gateway::CrossMsg> for CrossMsg {
 }
 
 /// Converts a Fil TokenAmount into an ethers::U256 amount.
-pub fn fil_to_eth_amount(amount: &TokenAmount) -> anyhow::Result<ethers::types::U256> {
-    ethers::types::U256::from_str(amount.atto().to_string().as_str())
-        .map_err(|e| anyhow!("invalid amount: {e}"))
+pub fn fil_to_eth_amount(amount: &TokenAmount) -> anyhow::Result<U256> {
+    Ok(U256::from(
+        amount
+            .atto()
+            .to_u128()
+            .ok_or_else(|| anyhow!("cannot convert value: {:?}", amount))?
+    ))
 }
 
 pub fn ethers_address_to_fil_address(addr: &ethers::types::Address) -> anyhow::Result<Address> {

--- a/src/manager/evm/mod.rs
+++ b/src/manager/evm/mod.rs
@@ -10,6 +10,7 @@ use fvm_shared::clock::ChainEpoch;
 use ipc_sdk::subnet_id::SubnetID;
 
 use super::subnet::SubnetManager;
+pub use conversion::{ethers_address_to_fil_address, fil_to_eth_amount};
 pub use manager::{gateway, subnet_contract, EthSubnetManager};
 
 #[async_trait]

--- a/src/manager/evm/mod.rs
+++ b/src/manager/evm/mod.rs
@@ -10,7 +10,7 @@ use fvm_shared::clock::ChainEpoch;
 use ipc_sdk::subnet_id::SubnetID;
 
 use super::subnet::SubnetManager;
-pub use conversion::{ethers_address_to_fil_address, fil_to_eth_amount};
+pub use conversion::{eth_to_fil_amount, ethers_address_to_fil_address, fil_to_eth_amount};
 pub use manager::{gateway, subnet_contract, EthSubnetManager};
 
 #[async_trait]

--- a/src/server/handlers/wallet/balances.rs
+++ b/src/server/handlers/wallet/balances.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 use crate::config::subnet::SubnetConfig;
+use crate::manager::evm::ethers_address_to_fil_address;
 use crate::manager::SubnetManager;
 use crate::server::handlers::manager::subnet::SubnetManagerPool;
 use crate::server::JsonRPCRequestHandler;
@@ -13,7 +14,6 @@ use fvm_shared::econ::TokenAmount;
 use ipc_identity::EvmKeyStore;
 use ipc_identity::{PersistentKeyStore, Wallet};
 use ipc_sdk::subnet_id::SubnetID;
-use primitives::EthAddress;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -130,12 +130,4 @@ impl JsonRPCRequestHandler for WalletBalancesHandler {
             SubnetConfig::Fevm(_) => self.fevm_balances(manager).await,
         }
     }
-}
-
-fn ethers_address_to_fil_address(addr: &ethers::types::Address) -> anyhow::Result<Address> {
-    let raw_addr = format!("{addr:?}");
-    log::debug!("raw evm subnet addr: {raw_addr:}");
-
-    let eth_addr = EthAddress::from_str(&raw_addr)?;
-    Ok(Address::from(eth_addr))
 }

--- a/src/server/handlers/wallet/balances.rs
+++ b/src/server/handlers/wallet/balances.rs
@@ -53,10 +53,8 @@ impl WalletBalancesHandler {
         &self,
         manager: &dyn SubnetManager,
     ) -> anyhow::Result<WalletBalancesResponse> {
-        let addresses = self.fvm_wallet.read().unwrap().list_addrs()?;
-        // Create a new Arc for wallet so it is pulled in the async block
-        // from below.
-        let _arc_wallet = Arc::clone(&self.fvm_wallet);
+        let wallet = Arc::clone(&self.fvm_wallet);
+        let addresses = wallet.read().unwrap().list_addrs()?;
 
         let r = addresses
             .iter()
@@ -85,10 +83,6 @@ impl WalletBalancesHandler {
     ) -> anyhow::Result<WalletBalancesResponse> {
         let keystore = Arc::clone(&self.evm_keystore);
         let addresses = keystore.read().unwrap().list()?;
-
-        // Create a new Arc for keystore so it is pulled in the async block
-        // from below.
-        let _arc_keystore = keystore.clone();
 
         let r = addresses
             .iter()


### PR DESCRIPTION
This PR: 
- It implements `send_value` support for EVM-based subnets
- Moves a few function arounds to improve code organization