### PR TITLE
remove confidence wait for StateWait in Lotus

### DIFF
--- a/src/lotus/client.rs
+++ b/src/lotus/client.rs
@@ -71,10 +71,10 @@ mod methods {
 }
 
 /// The default state wait confidence value
-/// TODO: we can afford 2 epochs confidence (and even one)
-/// with Mir, but with Filecoin mainnet this should be increased
+/// NOTE: we can afford 0 epochs confidence (and even one)
+/// with instant-finality consensus, but with Filecoin mainnet this should be increased
 /// in case there are reorgs.
-const STATE_WAIT_CONFIDENCE: u8 = 2;
+const STATE_WAIT_CONFIDENCE: u8 = 0;
 /// We dont set a limit on the look back epoch, i.e. check against latest block
 const STATE_WAIT_LOOK_BACK_NO_LIMIT: i8 = -1;
 /// We are not replacing any previous messages.


### PR DESCRIPTION
The Lotus client is only used when the subnet is of type `fvm`. This is currently only supported in child subnets running an instant-finality consensus (Mir/Tendermint), so we can afford having 0 epoch of confidence in state wait. This reduces the latency when interacting with the subnet from the IPC agent. 

In the same line, the PR increases the default polling time of the ETH provider to fit the block times of our instant finality subnets.