### PR TITLE
Add action to check and fix PR targets

### DIFF
--- a/.github/workflows/branch-check.yaml
+++ b/.github/workflows/branch-check.yaml
@@ -1,4 +1,4 @@
-name: Redirect PRs to dev branch
+name: Check branch
 
 on:
   pull_request_target: # Do not combine with explicit checkout for security reasons

--- a/.github/workflows/branch-check.yaml
+++ b/.github/workflows/branch-check.yaml
@@ -1,0 +1,21 @@
+name: Redirect PRs to dev branch
+
+on:
+  pull_request_target: # Do not combine with explicit checkout for security reasons
+    types: [opened] # Removed "edited" to allow a forced path to main if needed
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: Vankka/pr-target-branch-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target: main
+          exclude: dev # Don't prevent going from development -> main
+          change-to: dev
+          comment: |
+              Your PR was set to target `main`. PRs should be target `dev`.
+              The base branch of this PR has been automatically changed to `dev`.
+              If you really intend to target `main`, you may edit the PR.

--- a/.github/workflows/branch-check.yaml
+++ b/.github/workflows/branch-check.yaml
@@ -2,7 +2,7 @@ name: Redirect PRs to dev branch
 
 on:
   pull_request_target: # Do not combine with explicit checkout for security reasons
-    types: [opened] # Removed "edited" to allow a forced path to main if needed
+    types: [opened] # Not triggering on "edited" to allow a forced path to main
 
 jobs:
   check-branch:
@@ -18,4 +18,4 @@ jobs:
           comment: |
               Your PR was set to target `main`. PRs should be target `dev`.
               The base branch of this PR has been automatically changed to `dev`.
-              If you really intend to target `main`, you may edit the PR.
+              If you really intend to target `main`, edit the PR.


### PR DESCRIPTION
@adlrocha following slack discussion: this would allow us to retain main as the default while automatically redirecting in case some rattlebrain like me targets the wrong branch.