### PR TITLE
Adjust scripts/docs for lotus main as default

### DIFF
--- a/docs/quickstart-calibration.md
+++ b/docs/quickstart-calibration.md
@@ -249,7 +249,7 @@ echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc && source ~/.bashrc
 
 * Download and compile eudico (might take a while)
 ```bash
-git clone --branch spacenet https://github.com/consensus-shipyard/lotus.git
+git clone https://github.com/consensus-shipyard/lotus.git
 (cd lotus && make spacenet && make lotus-gateway)
 ```
 

--- a/docs/quickstart-spacenet.md
+++ b/docs/quickstart-spacenet.md
@@ -59,7 +59,7 @@ git clone https://github.com/consensus-shipyard/ipc-agent.git
 ```
 * Download and compile eudico (might take a while)
 ```bash
-git clone --branch spacenet https://github.com/consensus-shipyard/lotus.git
+git clone https://github.com/consensus-shipyard/lotus.git
 (cd lotus && make spacenet)
 ```
 

--- a/scripts/install_infra.sh
+++ b/scripts/install_infra.sh
@@ -6,7 +6,7 @@
 set -e
 
 rm -rf ./lotus
-git clone --branch spacenet https://github.com/consensus-shipyard/lotus.git
+git clone https://github.com/consensus-shipyard/lotus.git
 cd ./lotus
 
 uname=$(uname);


### PR DESCRIPTION
The lotus repo was the outlier in that the unstable `dev` branch was default. This switches the docs and scripts to match making `main` (aliased `spacenet`) the default branch.