### PR TITLE
IPC-287: Fix high premium in eth_call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,8 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b4026b97da8281276744741fac7eb385da905f6093c583331fa2953fdd4253"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1620,8 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcb6ffefc230d8c42874c51b28dc11dbb8de50b27a8fdf92648439d6baa68dc"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1631,13 +1633,15 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4719a44c3d37ab07c6dea99ab174068d8c35e441b60b6c20ce4e48357273e8"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
  "ethers-core",
  "ethers-providers",
+ "ethers-signers",
  "futures-util",
  "hex",
  "once_cell",
@@ -1649,8 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155ea1b84d169d231317ed86e307af6f2bed6b40dd17e5e94bc84da21cadb21c"
 dependencies = [
  "Inflector",
  "dunce",
@@ -1672,8 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8567ff196c4a37c1a8c90ec73bda0ad2062e191e4f0a6dc4d943e2ec4830fc88"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
@@ -1687,8 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60ca2514feb98918a0a31de7e1983c29f2267ebf61b2dc5d4294f91e5b866623"
 dependencies = [
  "arrayvec 0.7.4",
  "bytes",
@@ -1706,7 +1713,7 @@ dependencies = [
  "rlp",
  "serde",
  "serde_json",
- "strum",
+ "strum 0.25.0",
  "syn 2.0.28",
  "tempfile",
  "thiserror",
@@ -1716,8 +1723,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b3a8269d3df0ed6364bc05b4735b95f4bf830ce3aef87d5e760fb0e93e5b91"
 dependencies = [
  "ethers-core",
  "reqwest",
@@ -1730,8 +1738,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c339aad74ae5c451d27e0e49c7a3c7d22620b119b4f9291d7aa21f72d7f366"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1756,8 +1765,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b411b119f1cf0efb69e2190883dee731251882bb21270f893ee9513b3a697c48"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1791,8 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4864d387456a9c09a1157fa10e1528b29d90f1d859443acf06a1b23365fb518c"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1809,8 +1820,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.6"
-source = "git+https://github.com/cryptoAtwill/ethers-rs.git#c3212887a2e05f98d564a0f34a3a2b4717c48a01"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6c2b9625a2c639d46625f88acc2092a3cb35786c37f7c2128b3ca20f639b3c"
 dependencies = [
  "cfg-if",
  "dunce",
@@ -2954,7 +2966,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "serde_tuple",
- "strum",
+ "strum 0.24.1",
  "tempfile",
  "thiserror",
  "tokio",
@@ -3202,9 +3214,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
+checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -3215,7 +3227,7 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -3224,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.12"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
+checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 
 [[package]]
 name = "lazy_static"
@@ -4408,7 +4420,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.4",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -4419,14 +4431,8 @@ checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -5064,9 +5070,9 @@ dependencies = [
 
 [[package]]
 name = "solang-parser"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a94494913728908efa7a25a2dd2e4f037e714897985c24273c40596638ed909"
+checksum = "9c792fe9fae2a2f716846f214ca10d5a1e21133e0bf36cef34bcc4a852467b21"
 dependencies = [
  "itertools 0.10.5",
  "lalrpop",
@@ -5259,7 +5265,16 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
+]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+dependencies = [
+ "strum_macros 0.25.2",
 ]
 
 [[package]]
@@ -5273,6 +5288,19 @@ dependencies = [
  "quote",
  "rustversion",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8d03b598d3d0fff69bf533ee3ef19b8eeb342729596df84bcc7e1f96ec4059"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ ipc-subnet-actor = { git = "https://github.com/consensus-shipyard/ipc-actors.git
 ipc-gateway = { git = "https://github.com/consensus-shipyard/ipc-actors.git", features = [] }
 libipld = { version = "0.14", default-features = false, features = ["dag-cbor"] }
 primitives = { git = "https://github.com/consensus-shipyard/fvm-utils" }
-ethers = { git = "https://github.com/cryptoAtwill/ethers-rs.git" }
-ethers-contract = { git = "https://github.com/cryptoAtwill/ethers-rs.git" }
+ethers = "2.0.8"
+ethers-contract = "2.0.8"
 
 # Uncomment to point to you local versions
 # [patch."https://github.com/consensus-shipyard/fvm-utils"]


### PR DESCRIPTION
__Note: Do not merge yet, I want to thoroughly test before merging__

Fixes https://github.com/consensus-shipyard/ipc-agent/issues/276

`ethers` performs several Ethereum-specific assumptions to estimate the gas premium. When the premium is too low, it sets a default premium that corresponds to `3 nanoFiL`. The average premiums paid in Filecoin are lower than the ones in Filecoin, what led to `ethers` always setting the premium to the default value (quite high for the case of Filecoin). 

This PR addresses the issue by using a custom premium estimation based on the historical premium paid in the last few blocks. Unlike `ethers` we don't use a threshold trigger that sets the default premium. This gas estimation is used for every  `eth_call` from the agent.