### PR TITLE
Add gh action to upload binaries on release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,9 +17,8 @@ jobs:
       - name: Check out the project
         uses: actions/checkout@v3
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: nightly
           components: rustfmt
       - name: Check code formatting
@@ -62,9 +61,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           target: wasm32-unknown-unknown
           toolchain: ${{ matrix.rust }}
           components: rustfmt,clippy

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
           toolchain: ${{ matrix.rust }}
           components: rustfmt,clippy
 

--- a/.github/workflows/release-binaries.yaml
+++ b/.github/workflows/release-binaries.yaml
@@ -1,0 +1,29 @@
+name: Release binaries
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+  release:
+    types: [ created ]
+    
+jobs:
+  upload-assets:
+    strategy:
+      fail-fast: false      
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: universal-apple-darwin
+            os: macos-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: ipc-agent
+          target: ${{ matrix.target }}
+          archive: $bin-$tag-$target
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
On release, builds and attaches binaries for linux x64 and darwin universal (arm+x64).

Also replaces deprecated action (see https://github.com/consensus-shipyard/fendermint/pull/188#discussion_r1295111695)

Closes #292 