### PR TITLE
IPC-299: implement get-chain-id

### DIFF
--- a/ipc/cli/src/commands/subnet/rpc.rs
+++ b/ipc/cli/src/commands/subnet/rpc.rs
@@ -28,7 +28,7 @@ impl CommandLineHandler for RPCSubnet {
         };
 
         println!("rpc: {:?}", conn.subnet().rpc_http().to_string());
-        println!("chainID: {:?}", subnet.chain_id());
+        println!("chainID: {:?}", conn.manager().get_chain_id().await?);
         Ok(())
     }
 }

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -625,6 +625,18 @@ impl IpcProvider {
 
         conn.manager().get_block_hash(height).await
     }
+
+    pub async fn get_chain_id(&self, subnet: &SubnetID) -> anyhow::Result<String> {
+        let conn = match self.connection(subnet) {
+            None => return Err(anyhow!("target subnet not found")),
+            Some(conn) => conn,
+        };
+
+        let subnet_config = conn.subnet();
+        self.check_subnet(subnet_config)?;
+
+        conn.manager().get_chain_id().await
+    }
 }
 
 /// Lotus JSON keytype format

--- a/ipc/provider/src/manager/evm/manager.rs
+++ b/ipc/provider/src/manager/evm/manager.rs
@@ -587,6 +587,15 @@ impl SubnetManager for EthSubnetManager {
             genesis_epoch,
         })
     }
+
+    async fn get_chain_id(&self) -> Result<String> {
+        Ok(self
+            .ipc_contract_info
+            .provider
+            .get_chainid()
+            .await?
+            .to_string())
+    }
 }
 
 #[async_trait]

--- a/ipc/provider/src/manager/fevm.rs
+++ b/ipc/provider/src/manager/fevm.rs
@@ -230,6 +230,10 @@ impl SubnetManager for FevmSubnetManager {
             .get_validator_set(subnet_id, gateway, epoch)
             .await
     }
+
+    async fn get_chain_id(&self) -> anyhow::Result<String> {
+        self.evm_subnet_manager.get_chain_id().await
+    }
 }
 
 #[async_trait]

--- a/ipc/provider/src/manager/fvm/mod.rs
+++ b/ipc/provider/src/manager/fvm/mod.rs
@@ -395,6 +395,10 @@ impl<T: JsonRpcClient + Send + Sync> SubnetManager for LotusSubnetManager<T> {
             genesis_epoch,
         })
     }
+
+    async fn get_chain_id(&self) -> Result<String> {
+        unimplemented!()
+    }
 }
 
 impl<T: JsonRpcClient + Send + Sync> LotusSubnetManager<T> {

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -129,6 +129,11 @@ pub trait SubnetManager: Send + Sync + TopDownCheckpointQuery {
         gateway: Option<Address>,
         epoch: Option<ChainEpoch>,
     ) -> Result<QueryValidatorSetResponse>;
+
+    /// Get chainID for the network.
+    /// Returning as a `String` because the maximum value for an EVM
+    /// networks is a `U256` that wouldn't fit in an integer type.
+    async fn get_chain_id(&self) -> Result<String>;
 }
 
 /// Trait to interact with a subnet to query the necessary information for top down checkpoint.


### PR DESCRIPTION
This PR implements a `get_chain_id` convenient function to provider and exposes it in a cli command.