### PR TITLE
Minor clean up

### DIFF
--- a/ipc/cli/src/main.rs
+++ b/ipc/cli/src/main.rs
@@ -1,6 +1,5 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
-#![feature(try_blocks)]
 use ipc_provider::set_fil_network_from_env;
 
 #[tokio::main]

--- a/ipc/identity/src/evm/persistent.rs
+++ b/ipc/identity/src/evm/persistent.rs
@@ -89,8 +89,10 @@ impl<T: Clone + Eq + Hash + TryFrom<KeyInfo> + Default + ToString> KeyStore
 
 impl<T: Clone + Eq + Hash + TryFrom<KeyInfo> + Default + ToString> PersistentKeyStore<T> {
     pub fn new(path: PathBuf) -> Result<Self> {
-        if let Some(p) = path.parent() && !p.exists() {
-            return Err(anyhow!("parent does not exist for key store"));
+        if let Some(p) = path.parent() {
+            if !p.exists() {
+                return Err(anyhow!("parent does not exist for key store"));
+            }
         }
 
         let p = match File::open(&path) {

--- a/ipc/identity/src/lib.rs
+++ b/ipc/identity/src/lib.rs
@@ -1,7 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 
-#![feature(let_chains)]
 use std::str::FromStr;
 
 use anyhow::anyhow;

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: MIT
 //! Ipc agent sdk, contains the json rpc client to interact with the IPC agent rpc server.
 
-#![feature(let_chains)]
-
 use anyhow::anyhow;
 use base64::Engine;
 use config::ReloadableConfig;

--- a/ipc/sdk/Cargo.toml
+++ b/ipc/sdk/Cargo.toml
@@ -9,9 +9,7 @@ license-file.workspace = true
 
 [dependencies]
 anyhow = "1.0.56"
-fil_actors_runtime = { git = "https://github.com/consensus-shipyard/fvm-utils", optional = true, features = [
-  "fil-actor",
-] }
+fil_actors_runtime = { workspace = true, optional = true }
 fnv = "1.0.7"
 fvm_ipld_blockstore = { workspace = true }
 fvm_ipld_encoding = { workspace = true }
@@ -29,7 +27,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 serde_json = "1.0.95"
-
+fil_actors_runtime = { workspace = true }
 
 [features]
 default = ["fil-actor"]

--- a/ipc/sdk/src/checkpoint.rs
+++ b/ipc/sdk/src/checkpoint.rs
@@ -1,7 +1,7 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 //! Cross network messages related struct and utility functions.
-//!
+
 use crate::cross::CrossMsg;
 use crate::subnet_id::SubnetID;
 use crate::ValidatorSet;
@@ -9,10 +9,8 @@ use anyhow::anyhow;
 use cid::multihash::Code;
 use cid::multihash::MultihashDigest;
 use cid::Cid;
-use fil_actors_runtime::runtime::Runtime;
 use fvm_ipld_encoding::DAG_CBOR;
 use fvm_ipld_encoding::{serde_bytes, to_vec};
-use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::econ::TokenAmount;
 use lazy_static::lazy_static;
@@ -84,14 +82,6 @@ impl BottomUpCheckpoint {
     /// and replace with None.
     pub fn cross_msgs(&mut self) -> Option<Vec<CrossMsg>> {
         self.data.cross_msgs.cross_msgs.clone()
-    }
-
-    /// Agents may set the source of a checkpoint using f2-based subnetIDs, \
-    /// but actors are expected to use f0-based subnetIDs, thus the need to enforce
-    /// that the source is a f0-based subnetID.
-    pub fn enforce_f0_source(&mut self, rt: &impl Runtime) -> anyhow::Result<()> {
-        self.data.source = self.source().f0_id(rt);
-        Ok(())
     }
 
     /// Get the sum of values in cross messages
@@ -212,19 +202,6 @@ impl Validators {
             validators,
             total_weight: weight,
         }
-    }
-
-    /// Get the weight of a validator
-    /// It expects ID addresses as an input
-    pub fn get_validator_weight(&self, rt: &impl Runtime, addr: &Address) -> Option<TokenAmount> {
-        self.validators
-            .validators()
-            .iter()
-            .find(|x| match rt.resolve_address(&x.addr) {
-                Some(id) => id == *addr,
-                None => false,
-            })
-            .map(|v| v.weight.clone())
     }
 }
 

--- a/ipc/sdk/src/lib.rs
+++ b/ipc/sdk/src/lib.rs
@@ -10,10 +10,10 @@ pub mod checkpoint;
 pub mod cross;
 pub mod error;
 pub mod gateway;
-pub mod subnet;
-pub mod subnet_id;
 #[cfg(feature = "fil-actor")]
 mod runtime;
+pub mod subnet;
+pub mod subnet_id;
 
 /// Encodes the a ChainEpoch as a varInt for its use
 /// as a key of a HAMT. This serialization has been

--- a/ipc/sdk/src/lib.rs
+++ b/ipc/sdk/src/lib.rs
@@ -12,6 +12,8 @@ pub mod error;
 pub mod gateway;
 pub mod subnet;
 pub mod subnet_id;
+#[cfg(feature = "fil-actor")]
+mod runtime;
 
 /// Encodes the a ChainEpoch as a varInt for its use
 /// as a key of a HAMT. This serialization has been

--- a/ipc/sdk/src/runtime.rs
+++ b/ipc/sdk/src/runtime.rs
@@ -1,0 +1,32 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
+
+use fil_actors_runtime::runtime::Runtime;
+use fvm_shared::address::Address;
+use fvm_shared::econ::TokenAmount;
+use crate::checkpoint::{BottomUpCheckpoint, Validators};
+
+impl BottomUpCheckpoint {
+    /// Agents may set the source of a checkpoint using f2-based subnetIDs, \
+    /// but actors are expected to use f0-based subnetIDs, thus the need to enforce
+    /// that the source is a f0-based subnetID.
+    pub fn enforce_f0_source(&mut self, rt: &impl Runtime) -> anyhow::Result<()> {
+        self.data.source = self.source().f0_id(rt);
+        Ok(())
+    }
+}
+
+impl Validators {
+    /// Get the weight of a validator
+    /// It expects ID addresses as an input
+    pub fn get_validator_weight(&self, rt: &impl Runtime, addr: &Address) -> Option<TokenAmount> {
+        self.validators
+            .validators()
+            .iter()
+            .find(|x| match rt.resolve_address(&x.addr) {
+                Some(id) => id == *addr,
+                None => false,
+            })
+            .map(|v| v.weight.clone())
+    }
+}

--- a/ipc/sdk/src/runtime.rs
+++ b/ipc/sdk/src/runtime.rs
@@ -1,10 +1,10 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
 
+use crate::checkpoint::{BottomUpCheckpoint, Validators};
 use fil_actors_runtime::runtime::Runtime;
 use fvm_shared::address::Address;
 use fvm_shared::econ::TokenAmount;
-use crate::checkpoint::{BottomUpCheckpoint, Validators};
 
 impl BottomUpCheckpoint {
     /// Agents may set the source of a checkpoint using f2-based subnetIDs, \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "stable"
 components = ["clippy", "llvm-tools", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
Some minor code clean ups:
- Switching to stable rust and remove the above features:
    - There is unused features: `try_block`, which we can remove. 
    - Also there is `let_chain`, which we can easily bypass.
- Move all `fil_actor::Runtime` related to a separate module