### PR TITLE
FM-306: add method in provider to get genesis info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2575,6 +2575,7 @@ dependencies = [
  "ipc-identity",
  "ipc-provider",
  "ipc-sdk",
+ "libsecp256k1",
  "log",
  "num-derive",
  "num-traits",
@@ -2691,7 +2692,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#ad80d9b29c98473042c42b8f9cae5c7453620c25"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#d0620b852c331cb12b84fda33963bf08c5634ca6"
 dependencies = [
  "anyhow",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#e2624a563072a33b96ede3d3aafe0d78f87ed4ce"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=fm-306-genesis-getters#7c10abf617a82df0a0768d21ad8c5c2f6b16f9e1"
 dependencies = [
  "anyhow",
  "ethers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2691,7 +2691,7 @@ dependencies = [
 [[package]]
 name = "ipc_actors_abis"
 version = "0.1.0"
-source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=fm-306-genesis-getters#7c10abf617a82df0a0768d21ad8c5c2f6b16f9e1"
+source = "git+https://github.com/consensus-shipyard/ipc-solidity-actors.git?branch=dev#ad80d9b29c98473042c42b8f9cae5c7453620c25"
 dependencies = [
  "anyhow",
  "ethers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ libipld = { version = "0.14", default-features = false, features = ["dag-cbor"] 
 ethers = "2.0.8"
 ethers-contract = "2.0.8"
 
-ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "fm-306-genesis-getters" }
+ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "dev" }
 ipc-sdk = { path = "./ipc/sdk" }
 
 fvm_ipld_blockstore = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ libipld = { version = "0.14", default-features = false, features = ["dag-cbor"] 
 ethers = "2.0.8"
 ethers-contract = "2.0.8"
 
-ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "dev" }
+ipc_actors_abis = { git = "https://github.com/consensus-shipyard/ipc-solidity-actors.git", branch = "fm-306-genesis-getters" }
 ipc-sdk = { path = "./ipc/sdk" }
 
 fvm_ipld_blockstore = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ hex = "0.4.3"
 tempfile = "3.4.0"
 serde_json = { version = "1.0.91", features = ["raw_value"] }
 libipld = { version = "0.14", default-features = false, features = ["dag-cbor"] }
+libsecp256k1 = "0.7"
 ethers = "2.0.8"
 ethers-contract = "2.0.8"
 

--- a/ipc/cli/Cargo.toml
+++ b/ipc/cli/Cargo.toml
@@ -33,6 +33,7 @@ thiserror = { workspace = true }
 hex = { workspace = true }
 serde_tuple = { workspace = true }
 zeroize = "1.6.0"
+libsecp256k1 = { workspace = true }
 
 ethers-contract = { workspace = true }
 ethers = { workspace = true }

--- a/ipc/cli/src/commands/subnet/create.rs
+++ b/ipc/cli/src/commands/subnet/create.rs
@@ -40,6 +40,7 @@ impl CreateSubnet {
                 arguments
                     .active_validators_limit
                     .unwrap_or(DEFAULT_ACTIVE_VALIDATORS),
+                f64_to_token_amount(arguments.min_cross_msg_fee)?,
             )
             .await?;
 
@@ -81,4 +82,11 @@ pub struct CreateSubnetArgs {
     pub bottomup_check_period: ChainEpoch,
     #[arg(long, help = "The max number of active validators in subnet")]
     pub active_validators_limit: Option<u16>,
+    #[arg(
+        long,
+        short,
+        default_value = "0.000001",
+        help = "Minimum fee for cross-net messages in subnet (in whole FIL)"
+    )]
+    pub min_cross_msg_fee: f64,
 }

--- a/ipc/cli/src/commands/subnet/create.rs
+++ b/ipc/cli/src/commands/subnet/create.rs
@@ -36,7 +36,6 @@ impl CreateSubnet {
                 parent,
                 arguments.min_validators,
                 f64_to_token_amount(arguments.min_validator_stake)?,
-                f64_to_token_amount(arguments.min_cross_msg_fee)?,
                 arguments.bottomup_check_period,
                 arguments
                     .active_validators_limit
@@ -75,11 +74,16 @@ pub struct CreateSubnetArgs {
     pub from: Option<String>,
     #[arg(long, short, help = "The parent subnet to create the new actor in")]
     pub parent: String,
-    #[arg(long, short, help = "The minimal validator stake")]
+    #[arg(
+        long,
+        short,
+        help = "The minimum number of collateral required for validators"
+    )]
     pub min_validator_stake: f64,
-    #[arg(long, short, help = "The minimal cross message fee")]
-    pub min_cross_msg_fee: f64,
-    #[arg(long, help = "The minimal number of validators")]
+    #[arg(
+        long,
+        help = "Minimum number of validators required to bootstrap the subnet"
+    )]
     pub min_validators: u64,
     #[arg(long, help = "The bottom up checkpoint period in number of blocks")]
     pub bottomup_check_period: ChainEpoch,

--- a/ipc/cli/src/commands/subnet/list_subnets.rs
+++ b/ipc/cli/src/commands/subnet/list_subnets.rs
@@ -34,7 +34,7 @@ impl CommandLineHandler for ListSubnets {
         for (_, s) in ls.iter() {
             println!(
                 "{:?} - status: {:?}, collateral: {:?} FIL, circ.supply: {:?} FIL",
-                s.id,
+                s.id.to_string(),
                 s.status,
                 TokenAmount::from_whole(s.stake.atto().clone()),
                 TokenAmount::from_whole(s.circ_supply.atto().clone()),

--- a/ipc/cli/src/commands/wallet/balances.rs
+++ b/ipc/cli/src/commands/wallet/balances.rs
@@ -53,7 +53,9 @@ impl CommandLineHandler for WalletBalances {
                     .collect::<anyhow::Result<Vec<(TokenAmount, &EthKeyAddress)>>>()?;
 
                 for (balance, addr) in r {
-                    println!("{:?} - Balance: {}", addr.to_string(), balance);
+                    if addr.to_string() != String::from("default-key") {
+                        println!("{:?} - Balance: {}", addr.to_string(), balance);
+                    }
                 }
             }
             WalletType::Fvm => {

--- a/ipc/cli/src/commands/wallet/balances.rs
+++ b/ipc/cli/src/commands/wallet/balances.rs
@@ -53,7 +53,7 @@ impl CommandLineHandler for WalletBalances {
                     .collect::<anyhow::Result<Vec<(TokenAmount, &EthKeyAddress)>>>()?;
 
                 for (balance, addr) in r {
-                    if addr.to_string() != String::from("default-key") {
+                    if addr.to_string() != *"default-key".to_string() {
                         println!("{:?} - Balance: {}", addr.to_string(), balance);
                     }
                 }

--- a/ipc/cli/src/commands/wallet/mod.rs
+++ b/ipc/cli/src/commands/wallet/mod.rs
@@ -9,7 +9,7 @@ use clap::{Args, Subcommand};
 use self::default::{
     WalletGetDefault, WalletGetDefaultArgs, WalletSetDefault, WalletSetDefaultArgs,
 };
-use self::export::{WalletExport, WalletExportArgs};
+use self::export::{WalletExport, WalletExportArgs, WalletPublicKey, WalletPublicKeyArgs};
 use self::import::{WalletImport, WalletImportArgs};
 use self::remove::{WalletRemove, WalletRemoveArgs};
 
@@ -38,6 +38,7 @@ impl WalletCommandsArgs {
             Commands::Remove(args) => WalletRemove::handle(global, args).await,
             Commands::SetDefault(args) => WalletSetDefault::handle(global, args).await,
             Commands::GetDefault(args) => WalletGetDefault::handle(global, args).await,
+            Commands::PubKey(args) => WalletPublicKey::handle(global, args).await,
         }
     }
 }
@@ -51,4 +52,5 @@ pub(crate) enum Commands {
     Remove(WalletRemoveArgs),
     SetDefault(WalletSetDefaultArgs),
     GetDefault(WalletGetDefaultArgs),
+    PubKey(WalletPublicKeyArgs),
 }

--- a/ipc/identity/Cargo.toml
+++ b/ipc/identity/Cargo.toml
@@ -12,8 +12,8 @@ anyhow = { workspace = true }
 base64 = { workspace = true }
 blake2b_simd = { workspace = true }
 rand = { workspace = true }
+libsecp256k1 = { workspace = true }
 ahash = "0.8"
-libsecp256k1 = "0.7"
 argon2 = "0.5"
 xsalsa20poly1305 = "0.9"
 serde_ipld_dagcbor = "0.2"

--- a/ipc/provider/src/checkpoint.rs
+++ b/ipc/provider/src/checkpoint.rs
@@ -59,8 +59,9 @@ impl BottomUpCheckpointManager<EthSubnetManager> {
         keystore: Arc<RwLock<PersistentKeyStore<EthKeyAddress>>>,
     ) -> Result<Self> {
         let parent_handler =
-            EthSubnetManager::from_subnet_with_wallet_store(&parent, keystore.clone())?;
-        let child_handler = EthSubnetManager::from_subnet_with_wallet_store(&child, keystore)?;
+            EthSubnetManager::from_subnet_with_wallet_store(&parent, Some(keystore.clone()))?;
+        let child_handler =
+            EthSubnetManager::from_subnet_with_wallet_store(&child, Some(keystore))?;
         Self::new(parent, child, parent_handler, child_handler).await
     }
 }

--- a/ipc/provider/src/config/mod.rs
+++ b/ipc/provider/src/config/mod.rs
@@ -30,7 +30,7 @@ pub const JSON_RPC_VERSION: &str = "2.0";
 /// DefaulDEFAULT_CHAIN_IDSUBNET_e
 pub const DEFAULT_CONFIG_TEMPLATE: &str = r#"
 # Default configuration for Filecoin Calibration
-repo_path = "~/.ipc"
+keystore_path = "~/.ipc"
 
 [[subnets]]
 id = "/r314159"

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -704,7 +704,9 @@ fn new_fvm_wallet_from_config(config: Arc<Config>) -> anyhow::Result<KeyStore> {
     if let Some(repo_str) = repo_str {
         new_fvm_keystore_from_path(repo_str)
     } else {
-        Err(anyhow!("No keystore repo found in config"))
+        Err(anyhow!(
+            "No keystore repo found in config. Try using absolute path"
+        ))
     }
 }
 

--- a/ipc/provider/src/lib.rs
+++ b/ipc/provider/src/lib.rs
@@ -243,7 +243,6 @@ impl IpcProvider {
         parent: SubnetID,
         min_validators: u64,
         min_validator_stake: TokenAmount,
-        min_cross_msg_fee: TokenAmount,
         bottomup_check_period: ChainEpoch,
         active_validators_limit: u16,
         min_cross_msg_fee: TokenAmount,

--- a/ipc/provider/src/manager/mod.rs
+++ b/ipc/provider/src/manager/mod.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: MIT
 pub use crate::lotus::message::ipc::SubnetInfo;
 pub use evm::{EthManager, EthSubnetManager};
-pub use subnet::{GetBlockHashResult, SubnetManager, TopDownCheckpointQuery, TopDownQueryPayload};
+pub use subnet::{
+    GetBlockHashResult, SubnetGenesisInfo, SubnetManager, TopDownCheckpointQuery,
+    TopDownQueryPayload,
+};
 
 pub mod evm;
 mod subnet;

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -7,6 +7,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::{address::Address, econ::TokenAmount};
+use ipc_actors_abis::subnet_actor_getter_facet;
 use ipc_sdk::cross::CrossMsg;
 use ipc_sdk::staking::StakingChangeRequest;
 use ipc_sdk::subnet::ConstructParams;
@@ -111,6 +112,20 @@ pub trait SubnetManager: Send + Sync + TopDownCheckpointQuery {
     /// Returning as a `String` because the maximum value for an EVM
     /// networks is a `U256` that wouldn't fit in an integer type.
     async fn get_chain_id(&self) -> Result<String>;
+
+    /// Gets the genesis information required to bootstrap a child subnet
+    async fn get_genesis_info(&self, subnet: &SubnetID) -> Result<SubnetGenesisInfo>;
+}
+
+#[derive(Debug)]
+pub struct SubnetGenesisInfo {
+    pub bottom_up_checkpoint_period: u64,
+    pub msg_fee: TokenAmount,
+    pub majority_percentage: u8,
+    pub active_validators_limit: u16,
+    pub min_collateral: TokenAmount,
+    pub genesis_epoch: ChainEpoch,
+    pub validators: Vec<subnet_actor_getter_facet::Validator>,
 }
 
 /// The generic payload that returns the block hash of the data returning block with the actual

--- a/ipc/provider/src/manager/subnet.rs
+++ b/ipc/provider/src/manager/subnet.rs
@@ -7,12 +7,12 @@ use anyhow::Result;
 use async_trait::async_trait;
 use fvm_shared::clock::ChainEpoch;
 use fvm_shared::{address::Address, econ::TokenAmount};
-use ipc_actors_abis::subnet_actor_getter_facet;
 use ipc_sdk::checkpoint::BottomUpCheckpointBundle;
 use ipc_sdk::cross::CrossMsg;
 use ipc_sdk::staking::StakingChangeRequest;
 use ipc_sdk::subnet::ConstructParams;
 use ipc_sdk::subnet_id::SubnetID;
+use ipc_sdk::validator::Validator;
 
 use crate::lotus::message::ipc::SubnetInfo;
 
@@ -126,7 +126,7 @@ pub struct SubnetGenesisInfo {
     pub active_validators_limit: u16,
     pub min_collateral: TokenAmount,
     pub genesis_epoch: ChainEpoch,
-    pub validators: Vec<subnet_actor_getter_facet::Validator>,
+    pub validators: Vec<Validator>,
 }
 
 /// The generic payload that returns the block hash of the data returning block with the actual

--- a/ipc/sdk/src/checkpoint.rs
+++ b/ipc/sdk/src/checkpoint.rs
@@ -4,18 +4,14 @@
 
 use crate::cross::CrossMsg;
 use crate::subnet_id::SubnetID;
-use crate::ValidatorSet;
 use cid::multihash::Code;
 use cid::multihash::MultihashDigest;
 use cid::Cid;
 use fvm_ipld_encoding::DAG_CBOR;
 use fvm_shared::address::Address;
 use fvm_shared::clock::ChainEpoch;
-use fvm_shared::econ::TokenAmount;
 use lazy_static::lazy_static;
-use num_traits::Zero;
 use serde::{Deserialize, Serialize};
-use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 lazy_static! {
     // Default CID used for the genesis checkpoint. Using
@@ -59,28 +55,3 @@ pub struct BottomUpCheckpoint {
     /// approach we need with Lotus, where the messages are part of the relayed transaction.
     pub cross_messages_hash: Vec<u8>,
 }
-
-/// Validators tracks all the validator in the subnet. It is useful in handling top-down checkpoints.
-#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple)]
-pub struct Validators {
-    /// The validator set that holds all the validators
-    pub validators: ValidatorSet,
-    /// Tracks the total weight of the validators
-    pub total_weight: TokenAmount,
-}
-
-impl Validators {
-    pub fn new(validators: ValidatorSet) -> Self {
-        let mut weight = TokenAmount::zero();
-        for v in validators.validators() {
-            weight += v.weight.clone();
-        }
-        Self {
-            validators,
-            total_weight: weight,
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {}

--- a/ipc/sdk/src/lib.rs
+++ b/ipc/sdk/src/lib.rs
@@ -1,9 +1,6 @@
 // Copyright 2022-2023 Protocol Labs
 // SPDX-License-Identifier: MIT
-use fvm_ipld_encoding::tuple::{Deserialize_tuple, Serialize_tuple};
-use fvm_shared::clock::ChainEpoch;
 use fvm_shared::{address::Address, econ::TokenAmount};
-use integer_encoding::VarInt;
 use primitives::EthAddress;
 use std::str::FromStr;
 
@@ -16,80 +13,10 @@ pub mod gateway;
 mod runtime;
 pub mod subnet;
 pub mod subnet_id;
+pub mod validator;
 
 pub mod evm;
 pub mod staking;
-
-/// Encodes the a ChainEpoch as a varInt for its use
-/// as a key of a HAMT. This serialization has been
-/// tested to be compatible with its go counter-part
-/// in github.com/consensus-shipyard/go-ipc-types
-pub fn epoch_key(k: ChainEpoch) -> fvm_ipld_hamt::BytesKey {
-    let bz = k.encode_var_vec();
-    bz.into()
-}
-
-#[derive(Clone, Debug, Serialize_tuple, Deserialize_tuple, PartialEq, Eq)]
-pub struct Validator {
-    pub addr: Address,
-    pub net_addr: String,
-    // voting power for the validator determined by its stake in the
-    // network.
-    pub weight: TokenAmount,
-}
-
-#[derive(Clone, Default, Debug, Serialize_tuple, Deserialize_tuple, PartialEq, Eq)]
-pub struct ValidatorSet {
-    validators: Vec<Validator>,
-    // sequence number that uniquely identifies a validator set
-    configuration_number: u64,
-}
-
-impl ValidatorSet {
-    pub fn new(validators: Vec<Validator>, configuration_number: u64) -> Self {
-        Self {
-            validators,
-            configuration_number,
-        }
-    }
-
-    pub fn validators(&self) -> &Vec<Validator> {
-        &self.validators
-    }
-
-    pub fn validators_mut(&mut self) -> &mut Vec<Validator> {
-        &mut self.validators
-    }
-
-    pub fn config_number(&self) -> u64 {
-        self.configuration_number
-    }
-
-    /// Push a new validator to the validator set.
-    pub fn push(&mut self, val: Validator) {
-        self.validators.push(val);
-        // update the config_number with every update
-        // we allow config_number to overflow if that scenario ever comes.
-        self.configuration_number += 1;
-    }
-
-    /// Remove a validator from validator set by address
-    pub fn rm(&mut self, val: &Address) {
-        self.validators.retain(|x| x.addr != *val);
-        // update the config_number with every update
-        // we allow config_number to overflow if that scenario ever comes.
-        self.configuration_number += 1;
-    }
-
-    pub fn update_weight(&mut self, val: &Address, weight: &TokenAmount) {
-        self.validators_mut()
-            .iter_mut()
-            .filter(|x| x.addr == *val)
-            .for_each(|x| x.weight = weight.clone());
-
-        self.configuration_number += 1;
-    }
-}
 
 /// Converts an ethers::U256 TokenAmount into a FIL amount.
 pub fn eth_to_fil_amount(amount: &ethers::types::U256) -> anyhow::Result<TokenAmount> {

--- a/ipc/sdk/src/subnet.rs
+++ b/ipc/sdk/src/subnet.rs
@@ -23,6 +23,7 @@ pub struct ConstructParams {
     pub min_validators: u64,
     pub bottomup_check_period: ChainEpoch,
     pub active_validators_limit: u16,
+    pub min_cross_msg_fee: TokenAmount,
 }
 
 /// Consensus types supported by hierarchical consensus

--- a/ipc/sdk/src/validator.rs
+++ b/ipc/sdk/src/validator.rs
@@ -1,0 +1,57 @@
+// Copyright 2022-2023 Protocol Labs
+// SPDX-License-Identifier: MIT
+
+use fvm_shared::{address::Address, econ::TokenAmount};
+use ipc_actors_abis::subnet_actor_getter_facet;
+
+use crate::{
+    eth_to_fil_amount, ethers_address_to_fil_address,
+    evm::{fil_to_eth_amount, payload_to_evm_address},
+};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Validator {
+    pub addr: Address,
+    pub metadata: Vec<u8>,
+    pub weight: TokenAmount,
+}
+
+impl TryFrom<Validator> for subnet_actor_getter_facet::Validator {
+    type Error = anyhow::Error;
+
+    fn try_from(value: Validator) -> Result<Self, Self::Error> {
+        Ok(subnet_actor_getter_facet::Validator {
+            addr: payload_to_evm_address(value.addr.payload())?,
+            weight: fil_to_eth_amount(&value.weight)?,
+            metadata: ethers::core::types::Bytes::from(value.metadata),
+        })
+    }
+}
+
+pub fn into_contract_validators(
+    vals: Vec<Validator>,
+) -> anyhow::Result<Vec<subnet_actor_getter_facet::Validator>> {
+    let result: Result<Vec<subnet_actor_getter_facet::Validator>, _> = vals
+        .into_iter()
+        .map(|validator| validator.try_into())
+        .collect();
+
+    result
+}
+
+pub fn from_contract_validators(
+    vals: Vec<subnet_actor_getter_facet::Validator>,
+) -> anyhow::Result<Vec<Validator>> {
+    let result: Result<Vec<Validator>, _> = vals
+        .into_iter()
+        .map(|validator| {
+            Ok(Validator {
+                addr: ethers_address_to_fil_address(&validator.addr)?,
+                weight: eth_to_fil_amount(&validator.weight)?,
+                metadata: validator.metadata.to_vec(),
+            })
+        })
+        .collect();
+
+    result
+}


### PR DESCRIPTION
Related to https://github.com/consensus-shipyard/fendermint/issues/306
Depends on https://github.com/consensus-shipyard/ipc-agent/pull/336

This PR introduces a new method in the provider to retrieve all the genesis information in the parent required to deterministically generate the genesis for a Fendermint child subnet.

It also introduces `min_cross_msg_fee` as an additional configuration parameter that users can set when they create their subnets and many other changes.